### PR TITLE
fix(terraform-provider-fivetran): add missing host parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.0...HEAD)
 
+## [0.1.2](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.1...v0.1.2) - 2021-09-29
+
+## Fixed
+- `host` missing field added to connector schema.
+
 ## [0.1.1](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.0...v0.1.1) - 2021-09-28
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.0...HEAD)
 
-## [0.1.2](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.1...v0.1.2) - 2021-09-29
+## [0.1.2](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.1...v0.1.2) - 2021-09-30
 
 ## Fixed
 - `host` field added to resource connector config schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.1...v0.1.2) - 2021-09-29
 
 ## Fixed
-- `host` missing field added to connector schema.
+- `host` field added to resource connector config schema.
 
 ## [0.1.1](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.0...v0.1.1) - 2021-09-28
 

--- a/fivetran/resource_connector.go
+++ b/fivetran/resource_connector.go
@@ -891,7 +891,7 @@ func resourceConnectorCreateConfig(config []interface{}, schema string) *fivetra
 	if v := c["api_secret"].(string); v != "" {
 		fivetranConfig.APISecret(v)
 	}
-	if v := c["host"].(string); len(v) > 0 {
+	if v := c["host"].(string); v != "" {
 		fivetranConfig.Host(v)
 	}
 	if v := c["hosts"].([]interface{}); len(v) > 0 {

--- a/fivetran/resource_connector.go
+++ b/fivetran/resource_connector.go
@@ -891,6 +891,9 @@ func resourceConnectorCreateConfig(config []interface{}, schema string) *fivetra
 	if v := c["api_secret"].(string); v != "" {
 		fivetranConfig.APISecret(v)
 	}
+	if v := c["host"].(string); len(v) > 0 {
+		fivetranConfig.Host(v)
+	}
 	if v := c["hosts"].([]interface{}); len(v) > 0 {
 		fivetranConfig.Hosts(xInterfaceStrXStr(v))
 	}


### PR DESCRIPTION
Checked, the host is populated.  Closes [T-135508](https://fivetran.height.app/T-135508) 