### PR TITLE
Add cluster_id & cluster_region parameters to DestinationConfig schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.2.0...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.2.1...HEAD)
+
+## [0.2.1](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.2.0...v0.2.1) - 2021-12-13
+
+## Fixed
+- `cluster_id` missing field added to source destination schema.
+- `cluster_region` missing field added to source destination schema.
 
 ## [0.2.0](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.1.2...v0.2.0) - 2021-11-10
 

--- a/fivetran/data_source_destination.go
+++ b/fivetran/data_source_destination.go
@@ -50,6 +50,8 @@ func dataSourceDestinationSchemaConfig() *schema.Schema {
 				"auth_type":              {Type: schema.TypeString, Computed: true},
 				"role_arn":               {Type: schema.TypeString, Computed: true},
 				"secret_key":             {Type: schema.TypeString, Computed: true},
+				"cluster_id":             {Type: schema.TypeString, Computed: true},
+				"cluster_region":         {Type: schema.TypeString, Computed: true},
 			},
 		},
 	}
@@ -125,7 +127,8 @@ func dataSourceDestinationConfig(resp *fivetran.DestinationDetailsResponse) ([]i
 	c["auth_type"] = resp.Data.Config.AuthType
 	c["role_arn"] = resp.Data.Config.RoleArn
 	c["secret_key"] = resp.Data.Config.SecretKey
-
+	c["cluster_id"] = resp.Data.Config.ClusterId
+	c["cluster_region"] = resp.Data.Config.ClusterRegion
 	config = append(config, c)
 
 	return config, nil

--- a/fivetran/resource_destination.go
+++ b/fivetran/resource_destination.go
@@ -63,8 +63,10 @@ func resourceDestinationSchemaConfig() *schema.Schema {
 				"create_external_tables": {Type: schema.TypeString, Optional: true},
 				"external_location":      {Type: schema.TypeString, Optional: true},
 				"auth_type":              {Type: schema.TypeString, Optional: true},
-				"role_arn":               {Type: schema.TypeString, Optional: true},
-				"secret_key":             {Type: schema.TypeString, Optional: true},
+				"role_arn":               {Type: schema.TypeString, Optional: true, Sensitive: true},
+				"secret_key":             {Type: schema.TypeString, Optional: true, Sensitive: true},
+				"cluster_id":             {Type: schema.TypeString, Computed: true},
+				"cluster_region":         {Type: schema.TypeString, Computed: true},
 			},
 		},
 	}
@@ -222,6 +224,8 @@ func resourceDestinationReadConfig(resp *fivetran.DestinationDetailsResponse, cu
 	c["auth_type"] = resp.Data.Config.AuthType
 	c["role_arn"] = resp.Data.Config.RoleArn
 	c["secret_key"] = resp.Data.Config.SecretKey
+	c["cluster_id"] = resp.Data.Config.ClusterId
+	c["cluster_region"] = resp.Data.Config.ClusterRegion
 
 	config = append(config, c)
 
@@ -317,6 +321,14 @@ func resourceDestinationCreateConfig(config []interface{}) (*fivetran.Destinatio
 	}
 	if v := config[0].(map[string]interface{})["secret_key"].(string); v != "" {
 		fivetranConfig.SecretKey(v)
+		hasConfig = true
+	}
+	if v := config[0].(map[string]interface{})["cluster_id"].(string); v != "" {
+		fivetranConfig.ClusterId(v)
+		hasConfig = true
+	}
+	if v := config[0].(map[string]interface{})["cluster_region"].(string); v != "" {
+		fivetranConfig.ClusterRegion(v)
 		hasConfig = true
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/fivetran/terraform-provider-fivetran
 
 require (
-	github.com/fivetran/go-fivetran v0.3.0
+	github.com/fivetran/go-fivetran v0.3.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
 	github.com/mattn/go-colorable v0.1.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fivetran/go-fivetran v0.3.0 h1:Ay3Ta7HZg2q298eq06vGGsar0FJMoLjSss+ZKcffEA8=
-github.com/fivetran/go-fivetran v0.3.0/go.mod h1:Y0JRpTVn8sYRFcG5htzp9HhqfRE381QlHOHjVam+iyI=
+github.com/fivetran/go-fivetran v0.3.1 h1:zoRH0h5Ui1S7MvLjXFxlUibnJeNSLMFC+ZcuSxjPRks=
+github.com/fivetran/go-fivetran v0.3.1/go.mod h1:Y0JRpTVn8sYRFcG5htzp9HhqfRE381QlHOHjVam+iyI=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=


### PR DESCRIPTION
Added missing fields to destination config schema:
- cluster_id
- cluster_region
These fields are used to create and maintain state of Redshift destinations.