### PR TITLE
Fix crash on destination import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# VScode workspace files
+*.code-workspace
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.2.2...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.2.3...HEAD)
+
+## [0.2.3](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.2.2...v0.2.3) - 2022-01-10
+
+## Fixed
+- Crash on `terraform import fivetran_destination.name <group_id>`
 
 ## [0.2.2](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.2.1...v0.2.2) - 2021-12-31
 

--- a/fivetran/resource_destination.go
+++ b/fivetran/resource_destination.go
@@ -204,8 +204,10 @@ func resourceDestinationReadConfig(resp *fivetran.DestinationDetailsResponse, cu
 	c["database"] = resp.Data.Config.Database
 	c["auth"] = resp.Data.Config.Auth
 	c["user"] = resp.Data.Config.User
-	// The REST API sends the password field masked. We use the state stored password here.
-	c["password"] = currentConfig[0].(map[string]interface{})["password"].(string)
+	// The REST API sends the password field masked. We use the state stored password here if possible.
+	if len(currentConfig) > 0 {
+		c["password"] = currentConfig[0].(map[string]interface{})["password"].(string)
+	}
 	// connection_type is returned as ConnectionMethod
 	c["connection_type"] = dataSourceDestinationConfigNormalizeConnectionType(resp.Data.Config.ConnectionMethod)
 	c["tunnel_host"] = resp.Data.Config.TunnelHost


### PR DESCRIPTION
Fix crash on retrieving password value from current resource config. 
`currentConfig` is empty on resource imports.