### PR TITLE
Add connection_type property to connector config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.3.0...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.3.1...HEAD)
+
+## [0.3.1](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.3.0...v0.3.1) - 2022-01-31
+
+## Fixed
+- `ConnectorConfigRequest.ConnectionType` missing field added
 
 ## [0.3.0](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.2.3...v0.3.0) - 2022-01-25
 

--- a/fivetran/data_source_connector.go
+++ b/fivetran/data_source_connector.go
@@ -151,6 +151,7 @@ func dataSourceConnectorSchemaConfig() *schema.Schema {
 				"secrets":                           {Type: schema.TypeString, Computed: true},
 				"container_name":                    {Type: schema.TypeString, Computed: true},
 				"connection_string":                 {Type: schema.TypeString, Computed: true},
+				"connection_type":                   {Type: schema.TypeString, Computed: true},
 				"function_app":                      {Type: schema.TypeString, Computed: true},
 				"function_name":                     {Type: schema.TypeString, Computed: true},
 				"function_key":                      {Type: schema.TypeString, Computed: true},
@@ -483,6 +484,7 @@ func dataSourceConnectorReadConfig(resp *fivetran.ConnectorDetailsResponse) []in
 	mapAddStr(c, "secrets", resp.Data.Config.Secrets)
 	mapAddStr(c, "container_name", resp.Data.Config.ContainerName)
 	mapAddStr(c, "connection_string", resp.Data.Config.ConnectionString)
+	mapAddStr(c, "connection_type", resp.Data.Config.ConnectionType)
 	mapAddStr(c, "function_app", resp.Data.Config.FunctionApp)
 	mapAddStr(c, "function_name", resp.Data.Config.FunctionName)
 	mapAddStr(c, "function_key", resp.Data.Config.FunctionKey)

--- a/fivetran/data_source_destination.go
+++ b/fivetran/data_source_destination.go
@@ -109,8 +109,7 @@ func dataSourceDestinationConfig(resp *fivetran.DestinationDetailsResponse) ([]i
 	c["auth"] = resp.Data.Config.Auth
 	c["user"] = resp.Data.Config.User
 	c["password"] = resp.Data.Config.Password
-	// connection_type is returned as ConnectionMethod
-	c["connection_type"] = dataSourceDestinationConfigNormalizeConnectionType(resp.Data.Config.ConnectionMethod)
+	c["connection_type"] = dataSourceDestinationConfigNormalizeConnectionType(resp.Data.Config.ConnectionType)
 	c["tunnel_host"] = resp.Data.Config.TunnelHost
 	c["tunnel_port"] = resp.Data.Config.TunnelPort
 	c["tunnel_user"] = resp.Data.Config.TunnelUser

--- a/fivetran/resource_connector.go
+++ b/fivetran/resource_connector.go
@@ -170,6 +170,7 @@ func resourceConnectorSchemaConfig() *schema.Schema {
 				"secrets":                           {Type: schema.TypeString, Optional: true},
 				"container_name":                    {Type: schema.TypeString, Optional: true},
 				"connection_string":                 {Type: schema.TypeString, Optional: true},
+				"connection_type":                   {Type: schema.TypeString, Optional: true},
 				"function_app":                      {Type: schema.TypeString, Optional: true},
 				"function_name":                     {Type: schema.TypeString, Optional: true},
 				"function_key":                      {Type: schema.TypeString, Optional: true},
@@ -724,6 +725,9 @@ func resourceConnectorCreateConfig(config []interface{}, schema string) *fivetra
 	}
 	if v := c["connection_string"].(string); v != "" {
 		fivetranConfig.ConnectionString(v)
+	}
+	if v := c["connection_type"].(string); v != "" {
+		fivetranConfig.ConnectionType(v)
 	}
 	if v := c["function_app"].(string); v != "" {
 		fivetranConfig.FunctionApp(v)
@@ -1378,6 +1382,7 @@ func resourceConnectorReadConfig(resp *fivetran.ConnectorDetailsResponse, curren
 	mapAddStr(c, "secrets", resp.Data.Config.Secrets)
 	mapAddStr(c, "container_name", resp.Data.Config.ContainerName)
 	mapAddStr(c, "connection_string", resp.Data.Config.ConnectionString)
+	mapAddStr(c, "connection_type", resp.Data.Config.ConnectionType)
 	mapAddStr(c, "function_app", resp.Data.Config.FunctionApp)
 	mapAddStr(c, "function_name", resp.Data.Config.FunctionName)
 	mapAddStr(c, "function_key", resp.Data.Config.FunctionKey)

--- a/fivetran/resource_destination.go
+++ b/fivetran/resource_destination.go
@@ -41,15 +41,12 @@ func resourceDestinationSchemaConfig() *schema.Schema {
 	return &schema.Schema{Type: schema.TypeList, Required: true, MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"host":     {Type: schema.TypeString, Optional: true},
-				"port":     {Type: schema.TypeInt, Optional: true},
-				"database": {Type: schema.TypeString, Optional: true},
-				"auth":     {Type: schema.TypeString, Optional: true},
-				"user":     {Type: schema.TypeString, Optional: true},
-				"password": {Type: schema.TypeString, Optional: true, Sensitive: true},
-				// "connection_type", for example, is mandatory for some destinations. Configurations settings
-				// should be explicitly declared. Doing that, we avoid not declaring "connection_type"
-				// (or any other configuration) and the REST API returning it.
+				"host":                   {Type: schema.TypeString, Optional: true},
+				"port":                   {Type: schema.TypeInt, Optional: true},
+				"database":               {Type: schema.TypeString, Optional: true},
+				"auth":                   {Type: schema.TypeString, Optional: true},
+				"user":                   {Type: schema.TypeString, Optional: true},
+				"password":               {Type: schema.TypeString, Optional: true, Sensitive: true},
 				"connection_type":        {Type: schema.TypeString, Optional: true},
 				"tunnel_host":            {Type: schema.TypeString, Optional: true},
 				"tunnel_port":            {Type: schema.TypeString, Optional: true},
@@ -208,8 +205,7 @@ func resourceDestinationReadConfig(resp *fivetran.DestinationDetailsResponse, cu
 	if len(currentConfig) > 0 {
 		c["password"] = currentConfig[0].(map[string]interface{})["password"].(string)
 	}
-	// connection_type is returned as ConnectionMethod
-	c["connection_type"] = dataSourceDestinationConfigNormalizeConnectionType(resp.Data.Config.ConnectionMethod)
+	c["connection_type"] = dataSourceDestinationConfigNormalizeConnectionType(resp.Data.Config.ConnectionType)
 	c["tunnel_host"] = resp.Data.Config.TunnelHost
 	c["tunnel_port"] = resp.Data.Config.TunnelPort
 	c["tunnel_user"] = resp.Data.Config.TunnelUser

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/fivetran/terraform-provider-fivetran
 
 require (
-	github.com/fivetran/go-fivetran v0.5.0
+	github.com/fivetran/go-fivetran v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fivetran/go-fivetran v0.5.0 h1:zWg57ADxtKOYWUMkxvL+gnUDjE5FCjKhJRpkqgh6hDQ=
-github.com/fivetran/go-fivetran v0.5.0/go.mod h1:VZveAoj9lWCyGDuBRRbTU4M4j9sjjsAUBQIZld+J4Uc=
+github.com/fivetran/go-fivetran v0.5.1 h1:xw8XTWYq6S9+FKAIbhZt5AESfjhiqa/Dp4DWkCHKBkc=
+github.com/fivetran/go-fivetran v0.5.1/go.mod h1:VZveAoj9lWCyGDuBRRbTU4M4j9sjjsAUBQIZld+J4Uc=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=


### PR DESCRIPTION
New version of go-fivetran used.
Added connection_type property support in connector config schema.