### PR TITLE
[Bugfix] Client access overriding clientId with other attributes

### DIFF
--- a/fivetran/resource_connector.go
+++ b/fivetran/resource_connector.go
@@ -1278,13 +1278,13 @@ func resourceConnectorCreateAuthClientAccess(clientAccess []interface{}) *fivetr
 		fivetranAuthClientAccess.ClientID(v)
 	}
 	if v := ca["client_secret"].(string); v != "" {
-		fivetranAuthClientAccess.ClientID(v)
+		fivetranAuthClientAccess.ClientSecret(v)
 	}
 	if v := ca["user_agent"].(string); v != "" {
-		fivetranAuthClientAccess.ClientID(v)
+		fivetranAuthClientAccess.UserAgent(v)
 	}
 	if v := ca["developer_token"].(string); v != "" {
-		fivetranAuthClientAccess.ClientID(v)
+		fivetranAuthClientAccess.DeveloperToken(v)
 	}
 
 	return fivetranAuthClientAccess


### PR DESCRIPTION
**Issue**:
When setting up a salesforce connector using the clientId and clientSecret, we see that both the Terraform client_id and client_secret attribute are mapped to the clientId. This is also true for the user_agent and developer_token attribute.


**Solution**:
Remap the terraform attributes to the correct Go-API attributes.