### PR TITLE
Fix connector config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.4.2...HEAD)
 
+## [0.4.3](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.4.2...v0.4.3) - 2022-06-01
+
+## Fixed
+- Issue with `update_method` connector config field (now it can be effectively updated)
+- Issue with `connection_type` field isn't marked as readonlu no more
+
 ## [0.4.2](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.4.1...v0.4.2) - 2022-05-18
 
 ## Fixed

--- a/fivetran/resource_connector.go
+++ b/fivetran/resource_connector.go
@@ -95,7 +95,6 @@ func resourceConnectorSchemaConfig() *schema.Schema {
 				"authorization_method":      {Type: schema.TypeString, Computed: true},
 				"service_version":           {Type: schema.TypeString, Computed: true},
 				"last_synced_changes__utc_": {Type: schema.TypeString, Computed: true},
-				"connection_type":           {Type: schema.TypeString, Computed: true},
 
 				// Sensitive config fields, Fivetran returns this fields masked
 				"oauth_token":        {Type: schema.TypeString, Optional: true, Sensitive: true},
@@ -135,6 +134,7 @@ func resourceConnectorSchemaConfig() *schema.Schema {
 				"is_secure":                         {Type: schema.TypeString, Optional: true, Computed: true},
 				"use_webhooks":                      {Type: schema.TypeString, Optional: true, Computed: true},
 				// Enum & int values
+				"connection_type":                      {Type: schema.TypeString, Optional: true, Computed: true},
 				"sync_mode":                            {Type: schema.TypeString, Optional: true, Computed: true},
 				"date_granularity":                     {Type: schema.TypeString, Optional: true, Computed: true},
 				"timeframe_months":                     {Type: schema.TypeString, Optional: true, Computed: true},
@@ -1003,10 +1003,11 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData, creation bool) *fivet
 	if v := c["domain"].(string); v != "" {
 		fivetranConfig.Domain(v)
 	}
-	// The `update_method` value can be set only while connector creation and all further changes will be ignored
-	// This is a temporary workaround, once the problem with MySql connectors will be fixes - this stub will be removed
-	if v := c["update_method"].(string); creation && v != "" {
+	if v := c["update_method"].(string); v != "" {
 		fivetranConfig.UpdateMethod(v)
+	}
+	if v := c["connection_type"].(string); v != "" {
+		fivetranConfig.ConnectionType(v)
 	}
 	if v := c["replication_slot"].(string); v != "" {
 		fivetranConfig.ReplicationSlot(v)


### PR DESCRIPTION
Fixed:
- `update_method` stub removed (there was no ability to update the value due to bug in API)
- `connection_type` now editable field