### PR TITLE
docs(terraform): Add role param as Optional

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -29,6 +29,7 @@ resource "fivetran_user" "user" {
 
 - `phone` - The phone number of the user.
 - `picture` - The url of the user's avatar.
+- `role` - The account role that you would like to assign this new user to. Possible values: Account Administrator, Account Billing, Account Analyst, Account Reviewer, Destination Creator, or a custom role with account-level permissions..
 
 ### Read-Only
 


### PR DESCRIPTION
https://fivetran.com/docs/rest-api/users#inviteauser

https://fivetran.height.app/inbox/T-262815

The role parameter is currently required and missing from our documentation. The role parameter will be an optional field by the next deployment, and I'd like to add it as an optional field directly.