### PR TITLE
Adds public_key to destination output

### DIFF
--- a/docs/data-sources/destination.md
+++ b/docs/data-sources/destination.md
@@ -50,6 +50,7 @@ Read-Only:
 - `personal_access_token` 
 - `port`
 - `project_id` 
+- `public_key` 
 - `role_arn` 
 - `secret_key`
 - `server_host_name` 
@@ -57,5 +58,3 @@ Read-Only:
 - `tunnel_port` 
 - `tunnel_user` 
 - `user` 
-
-

--- a/fivetran/data_source_destination.go
+++ b/fivetran/data_source_destination.go
@@ -39,6 +39,7 @@ func dataSourceDestinationSchemaConfig() *schema.Schema {
 				"tunnel_host":            {Type: schema.TypeString, Computed: true},
 				"tunnel_port":            {Type: schema.TypeString, Computed: true},
 				"tunnel_user":            {Type: schema.TypeString, Computed: true},
+				"public_key":             {Type: schema.TypeString, Computed: true},
 				"project_id":             {Type: schema.TypeString, Computed: true},
 				"data_set_location":      {Type: schema.TypeString, Computed: true},
 				"bucket":                 {Type: schema.TypeString, Computed: true},
@@ -113,6 +114,7 @@ func dataSourceDestinationConfig(resp *fivetran.DestinationDetailsResponse) ([]i
 	c["tunnel_host"] = resp.Data.Config.TunnelHost
 	c["tunnel_port"] = resp.Data.Config.TunnelPort
 	c["tunnel_user"] = resp.Data.Config.TunnelUser
+	c["public_key"] = resp.Data.Config.PublicKey
 	c["project_id"] = resp.Data.Config.ProjectID
 	c["data_set_location"] = resp.Data.Config.DataSetLocation
 	c["bucket"] = resp.Data.Config.Bucket

--- a/fivetran/resource_destination.go
+++ b/fivetran/resource_destination.go
@@ -51,6 +51,7 @@ func resourceDestinationSchemaConfig() *schema.Schema {
 				"tunnel_host":            {Type: schema.TypeString, Optional: true},
 				"tunnel_port":            {Type: schema.TypeString, Optional: true},
 				"tunnel_user":            {Type: schema.TypeString, Optional: true},
+				"public_key":             {Type: schema.TypeString, Optional: true},
 				"project_id":             {Type: schema.TypeString, Optional: true},
 				"data_set_location":      {Type: schema.TypeString, Optional: true},
 				"bucket":                 {Type: schema.TypeString, Optional: true},
@@ -215,6 +216,7 @@ func resourceDestinationReadConfig(resp *fivetran.DestinationDetailsResponse, cu
 	c["tunnel_host"] = resp.Data.Config.TunnelHost
 	c["tunnel_port"] = resp.Data.Config.TunnelPort
 	c["tunnel_user"] = resp.Data.Config.TunnelUser
+	c["public_key"] = resp.Data.Config.PublicKey
 	c["project_id"] = resp.Data.Config.ProjectID
 	c["data_set_location"] = resp.Data.Config.DataSetLocation
 	c["bucket"] = resp.Data.Config.Bucket
@@ -283,6 +285,10 @@ func resourceDestinationCreateConfig(config []interface{}) (*fivetran.Destinatio
 	}
 	if v := config[0].(map[string]interface{})["tunnel_user"].(string); v != "" {
 		fivetranConfig.TunnelUser(v)
+		hasConfig = true
+	}
+	if v := config[0].(map[string]interface{})["public_key"].(string); v != "" {
+		fivetranConfig.PublicKey(v)
 		hasConfig = true
 	}
 	if v := config[0].(map[string]interface{})["project_id"].(string); v != "" {


### PR DESCRIPTION
Hello! To automatically configure a SSH tunnel target host using terraform, I need the public_key from fivetran to add to authorized_keys on the host. The public_key is already in the API response, I think this will expose it in terraform. 