### PR TITLE
Update Example Usage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,32 @@ Make sure you read the Fivetran REST API [documentation](https://fivetran.com/do
 ## Example Usage
 
 ```hcl
-provider "fivetran" {
+# Terraform 0.13+ uses the Terraform Registry:
+
+terraform {
+  required_providers {
+    fivetran = {
+      source = "fivetran/fivetran"
+    }
+  }
 }
+
+
+# Configure the Fivetran provider
+provider "fivetran" {
+  api_key = var.fivetran_api_key
+  api_secret = var.fivetran_api_secret
+}
+
+
+
+# Terraform 0.12- can be specified as:
+
+# Configure the Fivetran provider
+# provider "fivetran" {
+#   api_key = "${var.fivetran_api_key}"
+#   api_secret = "${var.fivetran_api_secret}"
+# }
 ```
 
 ## Known issues

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,18 +20,18 @@ Make sure you read the Fivetran REST API [documentation](https://fivetran.com/do
 terraform {
   required_providers {
     fivetran = {
-      source = "fivetran/fivetran"
+        version = "0.6.6"                            
+        source = "fivetran/fivetran"
     }
   }
 }
 
-
 # Configure the Fivetran provider
 provider "fivetran" {
-  api_key = var.fivetran_api_key
-  api_secret = var.fivetran_api_secret
+#   We recommend to use environment variables instead of explicit assignment
+#   api_key = var.fivetran_api_key
+#   api_secret = var.fivetran_api_secret
 }
-
 
 
 # Terraform 0.12- can be specified as:


### PR DESCRIPTION
While setting up Terraform for Fivetran, I had to look at other providers (specifically [DataDog](https://registry.terraform.io/providers/DataDog/datadog/latest/docs)) for instructions on how to configure the `fivetran' provider.

To make this clearer, I updated the Example Usage section with this configuration.