### PR TITLE
Fix schema config creation for new connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.7...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.8...HEAD)
+
+## [0.6.8](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.7...v0.6.8)
+
+## Fixed
+- Issue: Unable to create `fivetran_connector_schema_config` resource for newly created connector. 
 
 ## [0.6.7](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.6...v0.6.7)
 


### PR DESCRIPTION
While creating `fivetran_connector_schema_config` resource we ran into an error if connector doesn't have schema config.
If the connector is just created - we need to reload schema config first.
To fix the issue the appropriate call added to ensure the connector has schema reloaded and non-empty standard config.