### PR TITLE
fix drifting changes caused by elements order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.15...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.16...HEAD)
+
+## [0.6.16](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.16...v0.6.16)
+
+## Fixed
+- Issue with `fivetran_connector.config.packed_mode_tables` order
+- All collections transformed into sets to avoid drifting changes caused by elements order.
 
 ## [0.6.15](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.14...v0.6.15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.16...HEAD)
 
-## [0.6.16](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.16...v0.6.16)
+## [0.6.16](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.15...v0.6.16)
 
 ## Added
 - `fivetran_connector.config.group_name` field support
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - Issue with `fivetran_connector.config.packed_mode_tables` order
 - All collections transformed into sets to avoid drifting changes caused by elements order.
+- E2E tests updated 
 
 ## [0.6.15](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.14...v0.6.15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.16](https://github.com/fivetran/terraform-provider-fivetran/compare/v0.6.16...v0.6.16)
 
+## Added
+- `fivetran_connector.config.group_name` field support
+
 ## Fixed
 - Issue with `fivetran_connector.config.packed_mode_tables` order
 - All collections transformed into sets to avoid drifting changes caused by elements order.

--- a/docs/data-sources/connector.md
+++ b/docs/data-sources/connector.md
@@ -163,6 +163,7 @@ Read-Only:
 - `function_trigger` (String)
 - `gcs_bucket` (String)
 - `gcs_folder` (String)
+- `group_name` (String)
 - `home_folder` (String)
 - `host` (String)
 - `hosts` (List of String)

--- a/docs/resources/connector.md
+++ b/docs/resources/connector.md
@@ -209,6 +209,7 @@ Optional:
 - `function_trigger` (String, Sensitive)
 - `gcs_bucket` (String)
 - `gcs_folder` (String)
+- `group_name` (String)
 - `home_folder` (String)
 - `host` (String)
 - `hosts` (List of String)

--- a/fivetran/data_source_connector.go
+++ b/fivetran/data_source_connector.go
@@ -368,6 +368,7 @@ func dataSourceConnectorSchemaConfig() *schema.Schema {
 				"client_name":          {Type: schema.TypeString, Computed: true},
 				"domain_type":          {Type: schema.TypeString, Computed: true},
 				"connection_method":    {Type: schema.TypeString, Computed: true},
+				"group_name":           {Type: schema.TypeString, Computed: true},
 			},
 		},
 	}
@@ -759,6 +760,9 @@ func dataSourceConnectorReadConfig(resp *fivetran.ConnectorCustomMergedDetailsRe
 	}
 	if v, ok := resp.Data.CustomConfig["connection_method"].(string); ok {
 		mapAddStr(c, "connection_method", v)
+	}
+	if v, ok := resp.Data.CustomConfig["group_name"].(string); ok {
+		mapAddStr(c, "group_name", v)
 	}
 
 	config[0] = c

--- a/fivetran/resource_connector.go
+++ b/fivetran/resource_connector.go
@@ -302,6 +302,7 @@ func resourceConnectorSchemaConfig() *schema.Schema {
 				"client_name":           {Type: schema.TypeString, Optional: true},
 				"domain_type":           {Type: schema.TypeString, Optional: true},
 				"connection_method":     {Type: schema.TypeString, Optional: true},
+				"group_name":            {Type: schema.TypeString, Optional: true},
 
 				// Collections
 				"report_suites":            {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
@@ -607,6 +608,10 @@ func resourceConnectorUpdateCustomConfig(d *schema.ResourceData) *map[string]int
 	}
 
 	c := config[0].(map[string]interface{})
+
+	if v, ok := c["group_name"].(string); ok && v != "" {
+		configMap["group_name"] = v
+	}
 
 	if v, ok := c["sync_method"].(string); ok && v != "" {
 		configMap["sync_method"] = v
@@ -1749,6 +1754,10 @@ func resourceConnectorReadConfig(resp *fivetran.ConnectorCustomMergedDetailsResp
 
 	if v, ok := resp.Data.CustomConfig["sync_method"].(string); ok {
 		mapAddStr(c, "sync_method", v)
+	}
+
+	if v, ok := resp.Data.CustomConfig["group_name"].(string); ok {
+		mapAddStr(c, "group_name", v)
 	}
 
 	if v, ok := resp.Data.CustomConfig["pdb_name"].(string); ok {

--- a/fivetran/resource_connector.go
+++ b/fivetran/resource_connector.go
@@ -304,38 +304,38 @@ func resourceConnectorSchemaConfig() *schema.Schema {
 				"connection_method":     {Type: schema.TypeString, Optional: true},
 
 				// Collections
-				"report_suites":            {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"elements":                 {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"metrics":                  {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"advertisables":            {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"dimensions":               {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"selected_exports":         {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"apps":                     {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"sales_accounts":           {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"finance_accounts":         {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"projects":                 {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"user_profiles":            {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"report_configuration_ids": {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"accounts":                 {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"fields":                   {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"breakdowns":               {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"action_breakdowns":        {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"pages":                    {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"repositories":             {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"dimension_attributes":     {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"columns":                  {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"manager_accounts":         {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"profiles":                 {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"site_urls":                {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"api_keys":                 {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"advertisers_id":           {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"hosts":                    {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"advertisers":              {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"organizations":            {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"account_ids":              {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-				"packed_mode_tables":       {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"report_suites":            {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"elements":                 {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"metrics":                  {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"advertisables":            {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"dimensions":               {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"selected_exports":         {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"apps":                     {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"sales_accounts":           {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"finance_accounts":         {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"projects":                 {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"user_profiles":            {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"report_configuration_ids": {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"accounts":                 {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"fields":                   {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"breakdowns":               {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"action_breakdowns":        {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"pages":                    {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"repositories":             {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"dimension_attributes":     {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"columns":                  {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"manager_accounts":         {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"profiles":                 {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"site_urls":                {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"api_keys":                 {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"advertisers_id":           {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"hosts":                    {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"advertisers":              {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"organizations":            {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"account_ids":              {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+				"packed_mode_tables":       {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 
-				"secrets_list": {Type: schema.TypeList, Optional: true,
+				"secrets_list": {Type: schema.TypeSet, Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"key":   {Type: schema.TypeString, Required: true},
@@ -344,41 +344,41 @@ func resourceConnectorSchemaConfig() *schema.Schema {
 					},
 				},
 
-				"adobe_analytics_configurations": {Type: schema.TypeList, Optional: true,
+				"adobe_analytics_configurations": {Type: schema.TypeSet, Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"sync_mode":          {Type: schema.TypeString, Optional: true},
-							"report_suites":      {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"elements":           {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"metrics":            {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"calculated_metrics": {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"segments":           {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"report_suites":      {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"elements":           {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"metrics":            {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"calculated_metrics": {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"segments":           {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 						},
 					},
 				},
-				"reports": {Type: schema.TypeList, Optional: true,
+				"reports": {Type: schema.TypeSet, Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"table":           {Type: schema.TypeString, Optional: true},
 							"config_type":     {Type: schema.TypeString, Optional: true, Computed: true},
 							"prebuilt_report": {Type: schema.TypeString, Optional: true},
 							"report_type":     {Type: schema.TypeString, Optional: true, Computed: true},
-							"fields":          {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"dimensions":      {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"metrics":         {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"segments":        {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"fields":          {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"dimensions":      {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"metrics":         {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"segments":        {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 							"filter":          {Type: schema.TypeString, Optional: true},
 						},
 					},
 				},
-				"custom_tables": {Type: schema.TypeList, Optional: true,
+				"custom_tables": {Type: schema.TypeSet, Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"table_name":               {Type: schema.TypeString, Optional: true},
 							"config_type":              {Type: schema.TypeString, Optional: true, Computed: true},
-							"fields":                   {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"breakdowns":               {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"action_breakdowns":        {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"fields":                   {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"breakdowns":               {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"action_breakdowns":        {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 							"aggregation":              {Type: schema.TypeString, Optional: true, Computed: true},
 							"action_report_time":       {Type: schema.TypeString, Optional: true, Computed: true},
 							"click_attribution_window": {Type: schema.TypeString, Optional: true, Computed: true},
@@ -387,7 +387,7 @@ func resourceConnectorSchemaConfig() *schema.Schema {
 						},
 					},
 				},
-				"project_credentials": {Type: schema.TypeList, Optional: true,
+				"project_credentials": {Type: schema.TypeSet, Optional: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"project":    {Type: schema.TypeString, Optional: true},
@@ -682,8 +682,8 @@ func resourceConnectorUpdateCustomConfig(d *schema.ResourceData) *map[string]int
 		configMap["organization"] = v
 	}
 
-	if v, ok := c["packed_mode_tables"].([]interface{}); ok {
-		configMap["packed_mode_tables"] = xInterfaceStrXStr(v)
+	if v, ok := c["packed_mode_tables"]; ok {
+		configMap["packed_mode_tables"] = xInterfaceStrXStr(v.(*schema.Set).List())
 	}
 
 	if v, ok := c["access_key"].(string); ok && v != "" {
@@ -778,13 +778,13 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["sync_mode"].(string); v != "" {
 		fivetranConfig.SyncMode(v)
 	}
-	if v := c["report_suites"].([]interface{}); len(v) > 0 {
+	if v := c["report_suites"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.ReportSuites(xInterfaceStrXStr(v))
 	}
-	if v := c["elements"].([]interface{}); len(v) > 0 {
+	if v := c["elements"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Elements(xInterfaceStrXStr(v))
 	}
-	if v := c["metrics"].([]interface{}); len(v) > 0 {
+	if v := c["metrics"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Metrics(xInterfaceStrXStr(v))
 	}
 	if v := c["date_granularity"].(string); v != "" {
@@ -844,13 +844,13 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["is_keypair"].(string); v != "" {
 		fivetranConfig.IsKeypair(strToBool(v))
 	}
-	if v := c["advertisables"].([]interface{}); len(v) > 0 {
+	if v := c["advertisables"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Advertisables(xInterfaceStrXStr(v))
 	}
 	if v := c["report_type"].(string); v != "" {
 		fivetranConfig.ReportType(v)
 	}
-	if v := c["dimensions"].([]interface{}); len(v) > 0 {
+	if v := c["dimensions"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Dimensions(xInterfaceStrXStr(v))
 	}
 	if v := c["api_key"].(string); v != "" {
@@ -901,10 +901,10 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["skip_after"].(string); v != "" {
 		fivetranConfig.SkipAfter(strToInt(v))
 	}
-	if v := c["project_credentials"].([]interface{}); len(v) > 0 {
+	if v := c["project_credentials"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.ProjectCredentials(resourceConnectorCreateConfigProjectCredentials(v))
 	}
-	if v := c["secrets_list"].([]interface{}); len(v) > 0 {
+	if v := c["secrets_list"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.SecretsList(resourceConnectorCreateFunctionSecrets(v))
 	}
 	if v := c["auth_mode"].(string); v != "" {
@@ -922,7 +922,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["certificate"].(string); v != "" {
 		fivetranConfig.Certificate(v)
 	}
-	if v := c["selected_exports"].([]interface{}); len(v) > 0 {
+	if v := c["selected_exports"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.SelectedExports(xInterfaceStrXStr(v))
 	}
 	if v := c["consumer_group"].(string); v != "" {
@@ -940,13 +940,13 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["security_protocol"].(string); v != "" {
 		fivetranConfig.SecurityProtocol(v)
 	}
-	if v := c["apps"].([]interface{}); len(v) > 0 {
+	if v := c["apps"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Apps(xInterfaceStrXStr(v))
 	}
-	if v := c["sales_accounts"].([]interface{}); len(v) > 0 {
+	if v := c["sales_accounts"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.SalesAccounts(xInterfaceStrXStr(v))
 	}
-	if v := c["finance_accounts"].([]interface{}); len(v) > 0 {
+	if v := c["finance_accounts"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.FinanceAccounts(xInterfaceStrXStr(v))
 	}
 	if v := c["app_sync_mode"].(string); v != "" {
@@ -973,7 +973,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["sync_data_locker"].(string); v != "" {
 		fivetranConfig.SyncDataLocker(strToBool(v))
 	}
-	if v := c["projects"].([]interface{}); len(v) > 0 {
+	if v := c["projects"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Projects(xInterfaceStrXStr(v))
 	}
 	if v := c["function"].(string); v != "" {
@@ -1021,10 +1021,10 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["gcs_folder"].(string); v != "" {
 		fivetranConfig.GCSFolder(v)
 	}
-	if v := c["user_profiles"].([]interface{}); len(v) > 0 {
+	if v := c["user_profiles"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.UserProfiles(xInterfaceStrXStr(v))
 	}
-	if v := c["report_configuration_ids"].([]interface{}); len(v) > 0 {
+	if v := c["report_configuration_ids"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.ReportConfigurationIDs(xInterfaceStrXStr(v))
 	}
 	if v := c["enable_all_dimension_combinations"].(string); v != "" {
@@ -1036,16 +1036,16 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["aws_region_code"].(string); v != "" {
 		fivetranConfig.AWSRegionCode(v)
 	}
-	if v := c["accounts"].([]interface{}); len(v) > 0 {
+	if v := c["accounts"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Accounts(xInterfaceStrXStr(v))
 	}
-	if v := c["fields"].([]interface{}); len(v) > 0 {
+	if v := c["fields"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Fields(xInterfaceStrXStr(v))
 	}
-	if v := c["breakdowns"].([]interface{}); len(v) > 0 {
+	if v := c["breakdowns"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Breakdowns(xInterfaceStrXStr(v))
 	}
-	if v := c["action_breakdowns"].([]interface{}); len(v) > 0 {
+	if v := c["action_breakdowns"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.ActionBreakdowns(xInterfaceStrXStr(v))
 	}
 	if v := c["aggregation"].(string); v != "" {
@@ -1066,10 +1066,10 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["view_attribution_window"].(string); v != "" {
 		fivetranConfig.ViewAttributionWindow(v)
 	}
-	if v := c["custom_tables"].([]interface{}); len(v) > 0 {
+	if v := c["custom_tables"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.CustomTables(resourceConnectorCreateConfigCustomTables(v))
 	}
-	if v := c["pages"].([]interface{}); len(v) > 0 {
+	if v := c["pages"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Pages(xInterfaceStrXStr(v))
 	}
 	if v := c["subdomain"].(string); v != "" {
@@ -1084,16 +1084,16 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["is_secure"].(string); v != "" {
 		fivetranConfig.IsSecure(strToBool(v))
 	}
-	if v := c["repositories"].([]interface{}); len(v) > 0 {
+	if v := c["repositories"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Repositories(xInterfaceStrXStr(v))
 	}
 	if v := c["use_webhooks"].(string); v != "" {
 		fivetranConfig.UseWebhooks(strToBool(v))
 	}
-	if v := c["dimension_attributes"].([]interface{}); len(v) > 0 {
+	if v := c["dimension_attributes"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.DimensionAttributes(xInterfaceStrXStr(v))
 	}
-	if v := c["columns"].([]interface{}); len(v) > 0 {
+	if v := c["columns"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Columns(xInterfaceStrXStr(v))
 	}
 	if v := c["network_code"].(string); v != "" {
@@ -1102,16 +1102,16 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["customer_id"].(string); v != "" {
 		fivetranConfig.CustomerID(v)
 	}
-	if v := c["manager_accounts"].([]interface{}); len(v) > 0 {
+	if v := c["manager_accounts"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.ManagerAccounts(xInterfaceStrXStr(v))
 	}
-	if v := c["reports"].([]interface{}); len(v) > 0 {
+	if v := c["reports"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Reports(resourceConnectorCreateConfigReports(v))
 	}
 	if v := c["conversion_window_size"].(string); v != "" {
 		fivetranConfig.ConversionWindowSize(strToInt(v))
 	}
-	if v := c["profiles"].([]interface{}); len(v) > 0 {
+	if v := c["profiles"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Profiles(xInterfaceStrXStr(v))
 	}
 	if v := c["project_id"].(string); v != "" {
@@ -1135,7 +1135,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["update_config_on_each_sync"].(string); v != "" {
 		fivetranConfig.UpdateConfigOnEachSync(strToBool(v))
 	}
-	if v := c["site_urls"].([]interface{}); len(v) > 0 {
+	if v := c["site_urls"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.SiteURLs(xInterfaceStrXStr(v))
 	}
 	if v := c["path"].(string); v != "" {
@@ -1156,7 +1156,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["use_api_keys"].(string); v != "" {
 		fivetranConfig.UseAPIKeys(strToBool(v))
 	}
-	if v := c["api_keys"].([]interface{}); len(v) > 0 {
+	if v := c["api_keys"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.APIKeys(xInterfaceStrXStr(v))
 	}
 	if v := c["endpoint"].(string); v != "" {
@@ -1180,7 +1180,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["host"].(string); v != "" {
 		fivetranConfig.Host(v)
 	}
-	if v := c["hosts"].([]interface{}); len(v) > 0 {
+	if v := c["hosts"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Hosts(xInterfaceStrXStr(v))
 	}
 	if v := c["tunnel_host"].(string); v != "" {
@@ -1228,7 +1228,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["integration_key"].(string); v != "" {
 		fivetranConfig.IntegrationKey(v)
 	}
-	if v := c["advertisers"].([]interface{}); len(v) > 0 {
+	if v := c["advertisers"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Advertisers(xInterfaceStrXStr(v))
 	}
 	if v := c["engagement_attribution_window"].(string); v != "" {
@@ -1267,7 +1267,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["shop"].(string); v != "" {
 		fivetranConfig.Shop(v)
 	}
-	if v := c["organizations"].([]interface{}); len(v) > 0 {
+	if v := c["organizations"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.Organizations(xInterfaceStrXStr(v))
 	}
 	if v := c["swipe_attribution_window"].(string); v != "" {
@@ -1276,7 +1276,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["api_access_token"].(string); v != "" {
 		fivetranConfig.APIAccessToken(v)
 	}
-	if v := c["account_ids"].([]interface{}); len(v) > 0 {
+	if v := c["account_ids"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.AccountIDs(xInterfaceStrXStr(v))
 	}
 	if v := c["sid"].(string); v != "" {
@@ -1300,7 +1300,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["key"].(string); v != "" {
 		fivetranConfig.Key(v)
 	}
-	if v := c["advertisers_id"].([]interface{}); len(v) > 0 {
+	if v := c["advertisers_id"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.AdvertisersID(xInterfaceStrXStr(v))
 	}
 	if v := c["sync_format"].(string); v != "" {
@@ -1322,7 +1322,7 @@ func resourceConnectorUpdateConfig(d *schema.ResourceData) *fivetran.ConnectorCo
 	if v := c["is_new_package"].(string); v != "" {
 		fivetranConfig.IsNewPackage(strToBool(v))
 	}
-	if v := c["adobe_analytics_configurations"].([]interface{}); len(v) > 0 {
+	if v := c["adobe_analytics_configurations"].(*schema.Set).List(); len(v) > 0 {
 		fivetranConfig.AdobeAnalyticsConfigurations(resourceConnectorCreateConfigAdobeAnalyticsConfigurations(v))
 	}
 	if v := c["is_multi_entity_feature_enabled"].(string); v != "" {
@@ -1425,14 +1425,14 @@ func resourceConnectorCreateConfigCustomTables(xi []interface{}) []*fivetran.Con
 		if configType, ok := v.(map[string]interface{})["config_type"].(string); ok && configType != "" {
 			ct.ConfigType(configType)
 		}
-		if fields, ok := v.(map[string]interface{})["fields"].([]interface{}); ok && len(fields) > 0 {
-			ct.Fields(xInterfaceStrXStr(fields))
+		if fields, ok := v.(map[string]interface{})["fields"]; ok {
+			ct.Fields(xInterfaceStrXStr(fields.(*schema.Set).List()))
 		}
-		if breakdowns, ok := v.(map[string]interface{})["breakdowns"].([]interface{}); ok && len(breakdowns) > 0 {
-			ct.Breakdowns(xInterfaceStrXStr(breakdowns))
+		if breakdowns, ok := v.(map[string]interface{})["breakdowns"]; ok {
+			ct.Breakdowns(xInterfaceStrXStr(breakdowns.(*schema.Set).List()))
 		}
-		if actionBreakdowns, ok := v.(map[string]interface{})["action_breakdowns"].([]interface{}); ok && len(actionBreakdowns) > 0 {
-			ct.ActionBreakdowns(xInterfaceStrXStr(actionBreakdowns))
+		if actionBreakdowns, ok := v.(map[string]interface{})["action_breakdowns"]; ok {
+			ct.ActionBreakdowns(xInterfaceStrXStr(actionBreakdowns.(*schema.Set).List()))
 		}
 		if aggregation, ok := v.(map[string]interface{})["aggregation"].(string); ok && aggregation != "" {
 			ct.Aggregation(aggregation)
@@ -1463,20 +1463,20 @@ func resourceConnectorCreateConfigAdobeAnalyticsConfigurations(xi []interface{})
 		if syncMode, ok := v.(map[string]interface{})["sync_mode"].(string); ok && syncMode != "" {
 			c.SyncMode(syncMode)
 		}
-		if metrics, ok := v.(map[string]interface{})["metrics"].([]interface{}); ok && len(metrics) > 0 {
-			c.Metrics(xInterfaceStrXStr(metrics))
+		if metrics, ok := v.(map[string]interface{})["metrics"]; ok {
+			c.Metrics(xInterfaceStrXStr(metrics.(*schema.Set).List()))
 		}
-		if reportSuites, ok := v.(map[string]interface{})["report_suites"].([]interface{}); ok && len(reportSuites) > 0 {
-			c.ReportSuites(xInterfaceStrXStr(reportSuites))
+		if reportSuites, ok := v.(map[string]interface{})["report_suites"]; ok {
+			c.ReportSuites(xInterfaceStrXStr(reportSuites.(*schema.Set).List()))
 		}
-		if segments, ok := v.(map[string]interface{})["segments"].([]interface{}); ok && len(segments) > 0 {
-			c.Segments(xInterfaceStrXStr(segments))
+		if segments, ok := v.(map[string]interface{})["segments"]; ok {
+			c.Segments(xInterfaceStrXStr(segments.(*schema.Set).List()))
 		}
-		if elements, ok := v.(map[string]interface{})["elements"].([]interface{}); ok && len(elements) > 0 {
-			c.Elements(xInterfaceStrXStr(elements))
+		if elements, ok := v.(map[string]interface{})["elements"]; ok {
+			c.Elements(xInterfaceStrXStr(elements.(*schema.Set).List()))
 		}
-		if calculatedMetrics, ok := v.(map[string]interface{})["calculated_metrics"].([]interface{}); ok && len(calculatedMetrics) > 0 {
-			c.CalculatedMetrics(xInterfaceStrXStr(calculatedMetrics))
+		if calculatedMetrics, ok := v.(map[string]interface{})["calculated_metrics"]; ok {
+			c.CalculatedMetrics(xInterfaceStrXStr(calculatedMetrics.(*schema.Set).List()))
 		}
 
 		configurations[i] = c
@@ -1501,17 +1501,17 @@ func resourceConnectorCreateConfigReports(xi []interface{}) []*fivetran.Connecto
 		if reportType, ok := v.(map[string]interface{})["report_type"].(string); ok && reportType != "" {
 			r.ReportType(reportType)
 		}
-		if fields, ok := v.(map[string]interface{})["fields"].([]interface{}); ok && len(fields) > 0 {
-			r.Fields(xInterfaceStrXStr(fields))
+		if fields, ok := v.(map[string]interface{})["fields"]; ok {
+			r.Fields(xInterfaceStrXStr(fields.(*schema.Set).List()))
 		}
-		if dimensions, ok := v.(map[string]interface{})["dimensions"].([]interface{}); ok && len(dimensions) > 0 {
-			r.Dimensions(xInterfaceStrXStr(dimensions))
+		if dimensions, ok := v.(map[string]interface{})["dimensions"]; ok {
+			r.Dimensions(xInterfaceStrXStr(dimensions.(*schema.Set).List()))
 		}
-		if metrics, ok := v.(map[string]interface{})["metrics"].([]interface{}); ok && len(metrics) > 0 {
-			r.Metrics(xInterfaceStrXStr(metrics))
+		if metrics, ok := v.(map[string]interface{})["metrics"]; ok {
+			r.Metrics(xInterfaceStrXStr(metrics.(*schema.Set).List()))
 		}
-		if segments, ok := v.(map[string]interface{})["segments"].([]interface{}); ok && len(segments) > 0 {
-			r.Segments(xInterfaceStrXStr(segments))
+		if segments, ok := v.(map[string]interface{})["segments"]; ok {
+			r.Segments(xInterfaceStrXStr(segments.(*schema.Set).List()))
 		}
 		if filter, ok := v.(map[string]interface{})["filter"].(string); ok && filter != "" {
 			r.Filter(filter)
@@ -1663,7 +1663,7 @@ func resourceConnectorReadConfig(resp *fivetran.ConnectorCustomMergedDetailsResp
 		mapAddStr(c, "function_trigger", resourceConfig["function_trigger"].(string))
 		mapAddStr(c, "token_key", resourceConfig["token_key"].(string))
 		mapAddStr(c, "token_secret", resourceConfig["token_secret"].(string))
-		mapAddXInterface(c, "api_keys", resourceConfig["api_keys"].([]interface{}))
+		mapAddXInterface(c, "api_keys", resourceConfig["api_keys"].(*schema.Set).List())
 		mapAddStr(c, "agent_password", resourceConfig["agent_password"].(string))
 		mapAddStr(c, "asm_password", resourceConfig["asm_password"].(string))
 	}
@@ -2023,7 +2023,7 @@ func resourceConnectorReadConfigFlattenSecretsListGetStateValue(key string, curr
 }
 
 func getSubcollectionElementValue(configKey, subKey, subKeyValue, targetKey string, currentConfig []interface{}) interface{} {
-	targetList := currentConfig[0].(map[string]interface{})[configKey].([]interface{})
+	targetList := currentConfig[0].(map[string]interface{})[configKey].(*schema.Set).List()
 	for _, v := range targetList {
 		if v.(map[string]interface{})[subKey].(string) == subKeyValue {
 			return v.(map[string]interface{})[targetKey]

--- a/fivetran/resource_connector_test.go
+++ b/fivetran/resource_connector_test.go
@@ -25,16 +25,10 @@ func TestResourceConnectorE2E(t *testing.T) {
 
 			    resource "fivetran_connector" "test_connector" {
 					provider = fivetran-provider
-					lifecycle {` +
-					//Ignoring `auth_type` cause it returned by default but is abcent in config
-					`		
-						ignore_changes = ["config[0].auth_type"]
-					}
 					group_id = fivetran_group.test_group.id
-					service = "google_sheets"
+					service = "fivetran_log"
 					destination_schema {
-						name = "google_sheets_schema"
-						table = "table"
+						name = "fivetran_log_schema"
 					}
 					sync_frequency = 5
 					paused = true
@@ -44,15 +38,13 @@ func TestResourceConnectorE2E(t *testing.T) {
 					run_setup_tests = false
 			
 					config {
-						sheet_id = "1Rmq_FN2kTNwWiT4adZKBxHBRmvfeBTIfKWi5B8ii9qk"
-						named_range = "range"
+						group = fivetran_group.test_group.id
 					}
 				}
 		  `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testFivetranConnectorResourceCreate(t, "fivetran_connector.test_connector"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "google_sheets"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service_version", "1"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "fivetran_log"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "schedule_type", "auto"),
 
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.is_historical_sync", "true"),
@@ -60,17 +52,15 @@ func TestResourceConnectorE2E(t *testing.T) {
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.setup_state", "incomplete"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.sync_state", "paused"),
 
-					//schema_table format mutate schema to `schema` +`.` + `config.table`
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "google_sheets_schema.table"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "fivetran_log_schema"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "sync_frequency", "5"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "paused", "true"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "pause_after_trial", "true"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "trust_certificates", "false"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "trust_fingerprints", "false"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "run_setup_tests", "false"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.0.auth_type", "OAuth"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.0.sheet_id", "1Rmq_FN2kTNwWiT4adZKBxHBRmvfeBTIfKWi5B8ii9qk"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.0.named_range", "range"),
+
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.0.is_account_level_connector", "false"),
 				),
 			},
 			{
@@ -82,36 +72,26 @@ func TestResourceConnectorE2E(t *testing.T) {
 
 			    resource "fivetran_connector" "test_connector" {
 					provider = fivetran-provider
-					lifecycle {` +
-					//Ignoring `auth_type` cause it returned by default but is abcent in config
-					`
-						ignore_changes = ["config[0].auth_type"]
-					}
 					group_id = fivetran_group.test_group.id
-					service = "google_sheets"
-
+					service = "fivetran_log"
 					destination_schema {
-						name = "google_sheets_schema"
-						table = "table"
+						name = "fivetran_log_schema"
 					}
-					
 					sync_frequency = 15
 					paused = false
 					pause_after_trial = false
 					trust_certificates = true
 					trust_fingerprints = true
-					run_setup_tests = false
+					run_setup_tests = true
 			
 					config {
-						sheet_id = "1Rmq_RmvfeBTIfKWi5B8ii9qkFN2kTNwWiT4adZKBxHB"
-						named_range = "range_updated"
+						group = fivetran_group.test_group.id
 					}
 				}
 		  `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testFivetranConnectorResourceUpdate(t, "fivetran_connector.test_connector"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "google_sheets"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service_version", "1"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "fivetran_log"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "schedule_type", "auto"),
 
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.is_historical_sync", "true"),
@@ -119,17 +99,13 @@ func TestResourceConnectorE2E(t *testing.T) {
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.setup_state", "incomplete"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.sync_state", "scheduled"),
 
-					//schema_table format mutate schema to `schema` +`.` + `config.table`
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "google_sheets_schema.table"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "fivetran_log_schema"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "sync_frequency", "15"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "paused", "false"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "pause_after_trial", "false"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "trust_certificates", "true"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "trust_fingerprints", "true"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "run_setup_tests", "false"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.0.auth_type", "OAuth"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.0.sheet_id", "1Rmq_RmvfeBTIfKWi5B8ii9qkFN2kTNwWiT4adZKBxHB"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.0.named_range", "range_updated"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "run_setup_tests", "true"),
 				),
 			},
 		},

--- a/fivetran/resource_connector_test.go
+++ b/fivetran/resource_connector_test.go
@@ -38,7 +38,7 @@ func TestResourceConnectorE2E(t *testing.T) {
 					run_setup_tests = false
 			
 					config {
-						group = fivetran_group.test_group.id
+						group_name = fivetran_group.test_group.id
 					}
 				}
 		  `,
@@ -85,7 +85,7 @@ func TestResourceConnectorE2E(t *testing.T) {
 					run_setup_tests = true
 			
 					config {
-						group = fivetran_group.test_group.id
+						group_name = fivetran_group.test_group.id
 					}
 				}
 		  `,

--- a/fivetran/resource_connector_test.go
+++ b/fivetran/resource_connector_test.go
@@ -38,7 +38,7 @@ func TestResourceConnectorE2E(t *testing.T) {
 					run_setup_tests = false
 			
 					config {
-						group_name = fivetran_group.test_group.id
+						group_name = fivetran_group.test_group.name
 					}
 				}
 		  `,
@@ -85,7 +85,7 @@ func TestResourceConnectorE2E(t *testing.T) {
 					run_setup_tests = true
 			
 					config {
-						group_name = fivetran_group.test_group.id
+						group_name = fivetran_group.test_group.name
 					}
 				}
 		  `,

--- a/fivetran/resource_connector_test.go
+++ b/fivetran/resource_connector_test.go
@@ -96,7 +96,7 @@ func TestResourceConnectorE2E(t *testing.T) {
 
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.is_historical_sync", "true"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.update_state", "on_schedule"),
-					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.setup_state", "incomplete"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.setup_state", "connected"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "status.0.sync_state", "scheduled"),
 
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "fivetran_log_schema"),

--- a/fivetran/tests/mock/resource_connector_test.go
+++ b/fivetran/tests/mock/resource_connector_test.go
@@ -14,6 +14,10 @@ var (
 	connectorEmptyMockPostHandler *mock.Handler
 	connectorEmptyMockDelete      *mock.Handler
 
+	connectorListsMockGetHandler  *mock.Handler
+	connectorListsMockPostHandler *mock.Handler
+	connectorListsMockDelete      *mock.Handler
+
 	connectorMockGetHandler  *mock.Handler
 	connectorMockPostHandler *mock.Handler
 	connectorMockDelete      *mock.Handler
@@ -454,7 +458,467 @@ const (
         }
 	}
 	`
+
+	connectorConfigMappingTfConfig = `
+	resource "fivetran_connector" "test_connector" {
+		provider = fivetran-provider
+
+		group_id = "group_id"
+		service = "google_sheets"
+
+		destination_schema {
+			name = "google_sheets_schema"
+			table = "table"
+		}
+
+		sync_frequency = 5
+		paused = true
+		pause_after_trial = true
+		trust_certificates = false
+		trust_fingerprints = false
+		run_setup_tests = false
+
+		config {
+			sheet_id = "sheet_id"
+			named_range = "range"
+			auth_type = "OAuth"
+
+			oauth_token = "oauth_token" 
+			oauth_token_secret = "oauth_token_secret"
+			consumer_key = "consumer_key"
+			client_secret = "client_secret"
+			private_key = "private_key"
+			s3role_arn = "s3role_arn"
+			ftp_password = "ftp_password"
+			sftp_password = "sftp_password"
+			api_key = "api_key"
+			role_arn = "role_arn"
+			password = "password"
+			secret_key = "secret_key"
+			pem_certificate = "pem_certificate"
+			access_token = "access_token"
+			api_secret = "api_secret"
+			api_access_token = "api_access_token"
+			secret = "secret"
+			consumer_secret = "consumer_secret"
+			secrets = "secrets"
+			api_token = "api_token"
+			encryption_key = "encryption_key"
+			pat = "pat"
+			function_trigger = "function_trigger"
+			token_key = "token_key"
+			token_secret = "token_secret"
+
+			sync_method = "sync_method"
+
+			is_ftps = "false"
+			sftp_is_key_pair = "false"
+			sync_data_locker = "false"
+			enable_all_dimension_combinations = "false"
+			update_config_on_each_sync = "false"
+			on_premise = "false"
+			is_new_package = "false"
+			is_multi_entity_feature_enabled = "false"
+			always_encrypted = "false"
+			is_secure = "false"
+			use_api_keys = "false"
+			use_webhooks = "false"
+			eu_region = "false"
+			is_keypair = "false"
+			is_account_level_connector = "true"
+
+			conversion_window_size = "0"
+			skip_before = "0"
+			skip_after = "0"
+			ftp_port = "0"
+			sftp_port = "0"
+			port = "0"
+			tunnel_port = "0"
+			api_quota = "0"
+			daily_api_call_limit = "0"
+			agent_port = "0"
+
+			pdb_name = "pdb_name"
+			agent_host = "agent_host"
+			agent_user = "agent_user"
+			agent_password = "agent_password"
+			agent_public_cert = "agent_public_cert"
+			agent_ora_home = "agent_ora_home"
+			tns = "tns"
+			use_oracle_rac = "false"
+			is_single_table_mode = "true"
+			asm_option = "false"
+		    asm_user = "asm_user"
+			asm_password = "asm_password"
+			asm_oracle_home = "asm_oracle_home"
+			asm_tns = "asm_tns"
+			sap_user = "sap_user"
+
+			connection_type = "connection_type"
+			sync_mode = "sync_mode"
+			date_granularity = "date_granularity"
+			timeframe_months = "timeframe_months"
+			report_type = "report_type"
+			aggregation = "aggregation"
+			config_type = "config_type"
+			prebuilt_report = "prebuilt_report"
+			action_report_time = "action_report_time"
+			click_attribution_window = "click_attribution_window"
+			view_attribution_window = "view_attribution_window"
+			view_through_attribution_window_size = "view_through_attribution_window_size"
+			post_click_attribution_window_size = "post_click_attribution_window_size"
+			update_method = "update_method"
+			swipe_attribution_window = "swipe_attribution_window"
+			api_type = "api_type"
+			sync_format = "sync_format"
+			app_sync_mode = "app_sync_mode"
+			sales_account_sync_mode = "sales_account_sync_mode"
+			finance_account_sync_mode = "finance_account_sync_mode"
+			source = "source"
+			file_type = "file_type"
+			compression = "compression"
+			on_error = "on_error"
+			append_file_option = "append_file_option"
+			engagement_attribution_window = "engagement_attribution_window"
+			conversion_report_time = "conversion_report_time"
+
+			external_id = "external_id"
+			public_key = "public_key"
+
+			client_id = "client_id"
+			technical_account_id = "technical_account_id"
+			organization_id = "organization_id"
+			s3bucket = "s3bucket"
+			abs_connection_string = "abs_connection_string"
+			abs_container_name = "abs_container_name"
+			folder_id = "folder_id"
+			ftp_host = "ftp_host"
+			ftp_user = "ftp_user"
+			sftp_host = "sftp_host"
+			sftp_user = "sftp_user"
+			bucket = "bucket"
+			prefix = "prefix"
+			pattern = "pattern"
+			archive_pattern = "archive_pattern"
+			null_sequence = "null_sequence"
+			delimiter = "delimiter"
+			escape_char = "escape_char"
+			auth_mode = "auth_mode"
+			certificate = "certificate"
+			consumer_group = "consumer_group"
+			servers = "servers"
+			message_type = "message_type"
+			sync_type = "sync_type"
+			security_protocol = "security_protocol"
+			access_key_id = "access_key_id"
+			home_folder = "home_folder"
+			function = "function"
+			region = "region"
+			container_name = "container_name"
+			connection_string = "connection_string"
+			function_app = "function_app"
+			function_name = "function_name"
+			function_key = "function_key"
+			merchant_id = "merchant_id"
+			api_url = "api_url"
+			cloud_storage_type = "cloud_storage_type"
+			s3external_id = "s3external_id"
+			s3folder = "s3folder"
+			gcs_bucket = "gcs_bucket"
+			gcs_folder = "gcs_folder"
+			instance = "instance"
+			aws_region_code = "aws_region_code"
+			host = "host"
+
+			user = "user"
+			network_code = "network_code"
+			customer_id = "customer_id"
+			project_id = "project_id"
+			dataset_id = "dataset_id"
+			bucket_name = "bucket_name"
+			config_method = "config_method"
+			query_id = "query_id"
+			path = "path"
+			endpoint = "endpoint"
+			identity = "identity"
+			
+			domain_name = "domain_name"
+			resource_url = "resource_url"
+			tunnel_host = "tunnel_host"
+			tunnel_user = "tunnel_user"
+			database = "database"
+			datasource = "datasource"
+			account = "account"
+			role = "role"
+			email = "email"
+			account_id = "account_id"
+			server_url = "server_url"
+			user_key = "user_key"
+			api_version = "api_version"
+			time_zone = "time_zone"
+			integration_key = "integration_key"
+			domain = "domain"
+			replication_slot = "replication_slot"
+			publication_name = "publication_name"
+			data_center = "data_center"
+			sub_domain = "sub_domain"
+			subdomain = "subdomain"
+			test_table_name = "test_table_name"
+			shop = "shop"
+			sid = "sid"
+			key = "key"
+			bucket_service = "bucket_service"
+			user_name = "user_name"
+			username = "username"
+			report_url = "report_url"
+			unique_id = "unique_id"
+			base_url = "base_url"
+			entity_id = "entity_id"
+			soap_uri = "soap_uri"
+			user_id = "user_id"
+			share_url = "share_url"
+			organization = "organization"
+			access_key = "access_key"
+			domain_host_name = "domain_host_name"
+			client_name = "client_name"
+			domain_type = "domain_type"
+			connection_method = "connection_method"
+
+			report_suites = ["report_suite"]
+			elements = ["element"]
+			metrics = ["metric"]
+			advertisables = ["advertisable"]
+			dimensions = ["dimension"]
+			selected_exports = ["selected_export"]
+			apps = ["app"]
+			sales_accounts = ["sales_account"]
+			finance_accounts = ["finance_account"]
+			projects = ["project"]
+			user_profiles = ["user_profile"]
+			report_configuration_ids = ["report_configuration_id"]
+			accounts = ["account"]
+			fields = ["field"]
+			breakdowns = ["breakdown"]
+			action_breakdowns = ["action_breakdown"]
+			pages = ["page"]
+			repositories = ["repository"]
+			dimension_attributes = ["dimension_attribute"]
+			columns = ["column"]
+			manager_accounts = ["manager_account"]
+			profiles = ["profile"]
+			site_urls = ["site_url"]
+			api_keys = ["api_key"]
+			advertisers_id = ["advertiser_id"]
+			hosts = ["host"]
+			advertisers = ["advertiser"]
+			organizations = ["organization"]
+			account_ids = ["account_id"]
+			packed_mode_tables = ["packed_mode_table"]
+
+
+			adobe_analytics_configurations {
+				sync_mode = "sync_mode"
+				report_suites = ["report_suite"]
+				elements = ["element"]
+				metrics = ["metric"]
+				calculated_metrics = ["calculated_metric"]
+				segments = ["segment"]
+			}
+			reports {
+				table = "table"
+				config_type = "config_type"
+				prebuilt_report = "prebuilt_report"
+				report_type = "report_type"
+				fields = ["field"]
+				dimensions = ["dimension"]
+				metrics = ["metric"]
+				segments = ["segment"]
+				filter = "filter"
+			}
+			custom_tables {
+				table_name = "table_name"
+				config_type = "config_type"
+				fields = ["field"]
+				breakdowns = ["breakdown"]
+				action_breakdowns = ["action_breakdown"]
+				aggregation = "aggregation"
+				action_report_time = "action_report_time"
+				click_attribution_window = "click_attribution_window"
+				view_attribution_window = "view_attribution_window"
+				prebuilt_report_name = "prebuilt_report_name"
+			}
+			project_credentials {
+				project = "project"
+				api_key = "api_key"
+				secret_key = "secret_key"
+			}
+			secrets_list {
+				key = "key"
+				value = "value"
+			}
+		}
+
+		auth {
+			refresh_token = "refresh_token"
+			access_token = "access_token"
+			realm_id = "realm_id"
+			client_access {
+				client_id = "client_id"
+				client_secret = "client_secret"
+				user_agent = "user_agent"
+				developer_token = "developer_token"
+			}
+		}
+	}
+	`
+
+	connectorConfigListsMappingResponse = `
+	{
+		"id": "connector_id",
+        "group_id": "group_id",
+        "service": "google_sheets",
+        "service_version": 1,
+        "schema": "google_sheets_schema.table",
+        "paused": true,
+        "pause_after_trial": true,
+        "connected_by": "user_id",
+        "created_at": "2022-01-01T11:22:33.012345Z",
+        "succeeded_at": null,
+        "failed_at": null,
+        "sync_frequency": 5,
+		"schedule_type": "auto",
+        "status": {
+            "setup_state": "incomplete",
+            "sync_state": "paused",
+            "update_state": "on_schedule",
+            "is_historical_sync": true,
+            "tasks": [{
+				"code":"task_code",
+				"message":"task_message"
+			}],
+            "warnings": [{
+				"code":"warning_code",
+				"message":"warning_message"
+			}]
+        },
+        "setup_tests": [{
+            "title": "Validate Login",
+            "status": "FAILED",
+            "message": "Invalid login credentials"
+        }],
+        "config": {
+			"packed_mode_tables":["packed_mode_table_3", "packed_mode_table_2", "packed_mode_table_1"],
+			"report_suites": ["value_2", "value_1"],
+			"elements": ["value_2", "value_1"],
+			"metrics": ["value_2", "value_1"],
+			"advertisables": ["value_2", "value_1"],
+			"dimensions": ["value_2", "value_1"],
+			"selected_exports": ["value_2", "value_1"],
+			"apps": ["value_2", "value_1"],
+			"sales_accounts": ["value_2", "value_1"],
+			"finance_accounts": ["value_2", "value_1"],
+			"projects": ["value_2", "value_1"],
+			"user_profiles": ["value_2", "value_1"],
+			"report_configuration_ids": ["value_2", "value_1"],
+			"accounts": ["value_2", "value_1"],
+			"fields": ["value_2", "value_1"],
+			"breakdowns": ["value_2", "value_1"],
+			"action_breakdowns": ["value_2", "value_1"],
+			"pages": ["value_2", "value_1"],
+			"repositories": ["value_2", "value_1"],
+			"dimension_attributes": ["value_2", "value_1"],
+			"columns": ["value_2", "value_1"],
+			"manager_accounts": ["value_2", "value_1"],
+			"profiles": ["value_2", "value_1"],
+			"site_urls": ["value_2", "value_1"],
+			"api_keys": ["value_2", "value_1"],
+			"advertisers_id": ["value_2", "value_1"],
+			"hosts": ["value_2", "value_1"],
+			"advertisers": ["value_2", "value_1"],
+			"organizations": ["value_2", "value_1"],
+			"account_ids": ["value_2", "value_1"]
+		}
+	}
+	`
+
+	connectorConfigListsMappingTfConfig = `
+	resource "fivetran_connector" "test_connector" {
+		provider = fivetran-provider
+
+		group_id = "group_id"
+		service = "google_sheets"
+
+		destination_schema {
+			name = "google_sheets_schema"
+			table = "table"
+		}
+
+		sync_frequency = 5
+		paused = true
+		pause_after_trial = true
+		trust_certificates = false
+		trust_fingerprints = false
+		run_setup_tests = false
+
+		config {
+			packed_mode_tables = ["packed_mode_table_1", "packed_mode_table_2", "packed_mode_table_3"]
+			report_suites = ["value_1", "value_2"]
+			elements = ["value_1", "value_2"]
+			metrics = ["value_1", "value_2"]
+			advertisables = ["value_1", "value_2"]
+			dimensions = ["value_1", "value_2"]
+			selected_exports = ["value_1", "value_2"]
+			apps = ["value_1", "value_2"]
+			sales_accounts = ["value_1", "value_2"]
+			finance_accounts = ["value_1", "value_2"]
+			projects = ["value_1", "value_2"]
+			user_profiles = ["value_1", "value_2"]
+			report_configuration_ids = ["value_1", "value_2"]
+			accounts = ["value_1", "value_2"]
+			fields = ["value_1", "value_2"]
+			breakdowns = ["value_1", "value_2"]
+			action_breakdowns = ["value_1", "value_2"]
+			pages = ["value_1", "value_2"]
+			repositories = ["value_1", "value_2"]
+			dimension_attributes = ["value_1", "value_2"]
+			columns = ["value_1", "value_2"]
+			manager_accounts = ["value_1", "value_2"]
+			profiles = ["value_1", "value_2"]
+			site_urls = ["value_1", "value_2"]
+			api_keys = ["value_1", "value_2"]
+			advertisers_id = ["value_1", "value_2"]
+			hosts = ["value_1", "value_2"]
+			advertisers = ["value_1", "value_2"]
+			organizations = ["value_1", "value_2"]
+			account_ids = ["value_1", "value_2"]
+		}
+	}
+	`
 )
+
+func setupMockClientConnectorResourceListMappingConfig(t *testing.T) {
+	mockClient.Reset()
+
+	connectorListsMockGetHandler = mockClient.When(http.MethodGet, "/v1/connectors/connector_id").ThenCall(
+		func(req *http.Request) (*http.Response, error) {
+			return fivetranSuccessResponse(t, req, http.StatusOK, "Success", connectorMockData), nil
+		},
+	)
+
+	connectorListsMockPostHandler = mockClient.When(http.MethodPost, "/v1/connectors").ThenCall(
+		func(req *http.Request) (*http.Response, error) {
+			connectorMockData = createMapFromJsonString(t, connectorConfigListsMappingResponse)
+			return fivetranSuccessResponse(t, req, http.StatusCreated, "Success", connectorMockData), nil
+		},
+	)
+
+	connectorListsMockDelete = mockClient.When(http.MethodDelete, "/v1/connectors/connector_id").ThenCall(
+		func(req *http.Request) (*http.Response, error) {
+			connectorMockData = nil
+			return fivetranSuccessResponse(t, req, http.StatusOK, "Success", connectorMockData), nil
+		},
+	)
+}
 
 func setupMockClientConnectorResourceConfigMapping(t *testing.T) {
 	mockClient.Reset()
@@ -934,318 +1398,7 @@ func setupMockClientConnectorResourceEmptyConfig(t *testing.T) {
 func TestResourceConnectorConfigMappingMock(t *testing.T) {
 	// NOTE: the config is totally inconsistent and contains all possible values for mapping test
 	step1 := resource.TestStep{
-		Config: `
-		resource "fivetran_connector" "test_connector" {
-			provider = fivetran-provider
-
-			group_id = "group_id"
-			service = "google_sheets"
-
-			destination_schema {
-				name = "google_sheets_schema"
-				table = "table"
-			}
-
-			sync_frequency = 5
-			paused = true
-			pause_after_trial = true
-			trust_certificates = false
-			trust_fingerprints = false
-			run_setup_tests = false
-
-			config {
-				sheet_id = "sheet_id"
-				named_range = "range"
-				auth_type = "OAuth"
-
-				oauth_token = "oauth_token" 
-				oauth_token_secret = "oauth_token_secret"
-				consumer_key = "consumer_key"
-				client_secret = "client_secret"
-				private_key = "private_key"
-				s3role_arn = "s3role_arn"
-				ftp_password = "ftp_password"
-				sftp_password = "sftp_password"
-				api_key = "api_key"
-				role_arn = "role_arn"
-				password = "password"
-				secret_key = "secret_key"
-				pem_certificate = "pem_certificate"
-				access_token = "access_token"
-				api_secret = "api_secret"
-				api_access_token = "api_access_token"
-				secret = "secret"
-				consumer_secret = "consumer_secret"
-				secrets = "secrets"
-				api_token = "api_token"
-				encryption_key = "encryption_key"
-				pat = "pat"
-				function_trigger = "function_trigger"
-				token_key = "token_key"
-				token_secret = "token_secret"
-
-				sync_method = "sync_method"
-
-				is_ftps = "false"
-				sftp_is_key_pair = "false"
-				sync_data_locker = "false"
-				enable_all_dimension_combinations = "false"
-				update_config_on_each_sync = "false"
-				on_premise = "false"
-				is_new_package = "false"
-				is_multi_entity_feature_enabled = "false"
-				always_encrypted = "false"
-				is_secure = "false"
-				use_api_keys = "false"
-				use_webhooks = "false"
-				eu_region = "false"
-				is_keypair = "false"
-				is_account_level_connector = "true"
-
-				conversion_window_size = "0"
-				skip_before = "0"
-				skip_after = "0"
-				ftp_port = "0"
-				sftp_port = "0"
-				port = "0"
-				tunnel_port = "0"
-				api_quota = "0"
-				daily_api_call_limit = "0"
-				agent_port = "0"
-
-				pdb_name = "pdb_name"
-				agent_host = "agent_host"
-				agent_user = "agent_user"
-				agent_password = "agent_password"
-				agent_public_cert = "agent_public_cert"
-				agent_ora_home = "agent_ora_home"
-				tns = "tns"
-				use_oracle_rac = "false"
-				is_single_table_mode = "true"
-			    asm_option = "false"
-               asm_user = "asm_user"
-				asm_password = "asm_password"
-				asm_oracle_home = "asm_oracle_home"
-				asm_tns = "asm_tns"
-				sap_user = "sap_user"
-
-				connection_type = "connection_type"
-				sync_mode = "sync_mode"
-				date_granularity = "date_granularity"
-				timeframe_months = "timeframe_months"
-				report_type = "report_type"
-				aggregation = "aggregation"
-				config_type = "config_type"
-				prebuilt_report = "prebuilt_report"
-				action_report_time = "action_report_time"
-				click_attribution_window = "click_attribution_window"
-				view_attribution_window = "view_attribution_window"
-				view_through_attribution_window_size = "view_through_attribution_window_size"
-				post_click_attribution_window_size = "post_click_attribution_window_size"
-				update_method = "update_method"
-				swipe_attribution_window = "swipe_attribution_window"
-				api_type = "api_type"
-				sync_format = "sync_format"
-				app_sync_mode = "app_sync_mode"
-				sales_account_sync_mode = "sales_account_sync_mode"
-				finance_account_sync_mode = "finance_account_sync_mode"
-				source = "source"
-				file_type = "file_type"
-				compression = "compression"
-				on_error = "on_error"
-				append_file_option = "append_file_option"
-				engagement_attribution_window = "engagement_attribution_window"
-			    conversion_report_time = "conversion_report_time"
-
-				external_id = "external_id"
-				public_key = "public_key"
-
-				client_id = "client_id"
-				technical_account_id = "technical_account_id"
-				organization_id = "organization_id"
-				s3bucket = "s3bucket"
-				abs_connection_string = "abs_connection_string"
-				abs_container_name = "abs_container_name"
-				folder_id = "folder_id"
-				ftp_host = "ftp_host"
-				ftp_user = "ftp_user"
-				sftp_host = "sftp_host"
-				sftp_user = "sftp_user"
-				bucket = "bucket"
-				prefix = "prefix"
-				pattern = "pattern"
-				archive_pattern = "archive_pattern"
-				null_sequence = "null_sequence"
-				delimiter = "delimiter"
-				escape_char = "escape_char"
-				auth_mode = "auth_mode"
-				certificate = "certificate"
-				consumer_group = "consumer_group"
-				servers = "servers"
-				message_type = "message_type"
-				sync_type = "sync_type"
-				security_protocol = "security_protocol"
-				access_key_id = "access_key_id"
-				home_folder = "home_folder"
-				function = "function"
-				region = "region"
-				container_name = "container_name"
-				connection_string = "connection_string"
-				function_app = "function_app"
-				function_name = "function_name"
-				function_key = "function_key"
-				merchant_id = "merchant_id"
-				api_url = "api_url"
-				cloud_storage_type = "cloud_storage_type"
-				s3external_id = "s3external_id"
-				s3folder = "s3folder"
-				gcs_bucket = "gcs_bucket"
-				gcs_folder = "gcs_folder"
-				instance = "instance"
-				aws_region_code = "aws_region_code"
-				host = "host"
-
-				user = "user"
-				network_code = "network_code"
-				customer_id = "customer_id"
-				project_id = "project_id"
-				dataset_id = "dataset_id"
-				bucket_name = "bucket_name"
-				config_method = "config_method"
-				query_id = "query_id"
-				path = "path"
-				endpoint = "endpoint"
-				identity = "identity"
-				
-				domain_name = "domain_name"
-				resource_url = "resource_url"
-				tunnel_host = "tunnel_host"
-				tunnel_user = "tunnel_user"
-				database = "database"
-				datasource = "datasource"
-				account = "account"
-				role = "role"
-				email = "email"
-				account_id = "account_id"
-				server_url = "server_url"
-				user_key = "user_key"
-				api_version = "api_version"
-				time_zone = "time_zone"
-				integration_key = "integration_key"
-				domain = "domain"
-				replication_slot = "replication_slot"
-				publication_name = "publication_name"
-				data_center = "data_center"
-				sub_domain = "sub_domain"
-				subdomain = "subdomain"
-				test_table_name = "test_table_name"
-				shop = "shop"
-				sid = "sid"
-				key = "key"
-				bucket_service = "bucket_service"
-				user_name = "user_name"
-				username = "username"
-				report_url = "report_url"
-				unique_id = "unique_id"
-				base_url = "base_url"
-				entity_id = "entity_id"
-				soap_uri = "soap_uri"
-				user_id = "user_id"
-				share_url = "share_url"
-				organization = "organization"
-				access_key = "access_key"
-				domain_host_name = "domain_host_name"
-				client_name = "client_name"
-				domain_type = "domain_type"
-				connection_method = "connection_method"
-
-				report_suites = ["report_suite"]
-				elements = ["element"]
-				metrics = ["metric"]
-				advertisables = ["advertisable"]
-				dimensions = ["dimension"]
-				selected_exports = ["selected_export"]
-				apps = ["app"]
-				sales_accounts = ["sales_account"]
-				finance_accounts = ["finance_account"]
-				projects = ["project"]
-				user_profiles = ["user_profile"]
-				report_configuration_ids = ["report_configuration_id"]
-				accounts = ["account"]
-				fields = ["field"]
-			    breakdowns = ["breakdown"]
-				action_breakdowns = ["action_breakdown"]
-				pages = ["page"]
-				repositories = ["repository"]
-				dimension_attributes = ["dimension_attribute"]
-				columns = ["column"]
-				manager_accounts = ["manager_account"]
-				profiles = ["profile"]
-				site_urls = ["site_url"]
-				api_keys = ["api_key"]
-				advertisers_id = ["advertiser_id"]
-				hosts = ["host"]
-				advertisers = ["advertiser"]
-				organizations = ["organization"]
-				account_ids = ["account_id"]
-				packed_mode_tables = ["packed_mode_table"]
-
-
-				adobe_analytics_configurations {
-					sync_mode = "sync_mode"
-					report_suites = ["report_suite"]
-					elements = ["element"]
-					metrics = ["metric"]
-					calculated_metrics = ["calculated_metric"]
-					segments = ["segment"]
-				}
-				reports {
-					table = "table"
-					config_type = "config_type"
-					prebuilt_report = "prebuilt_report"
-					report_type = "report_type"
-					fields = ["field"]
-					dimensions = ["dimension"]
-					metrics = ["metric"]
-					segments = ["segment"]
-					filter = "filter"
-				}
-				custom_tables {
-					table_name = "table_name"
-					config_type = "config_type"
-					fields = ["field"]
-					breakdowns = ["breakdown"]
-					action_breakdowns = ["action_breakdown"]
-					aggregation = "aggregation"
-					action_report_time = "action_report_time"
-					click_attribution_window = "click_attribution_window"
-					view_attribution_window = "view_attribution_window"
-					prebuilt_report_name = "prebuilt_report_name"
-				}
-				project_credentials {
-					project = "project"
-					api_key = "api_key"
-					secret_key = "secret_key"
-				}
-				secrets_list {
-					key = "key"
-					value = "value"
-				}
-			}
-
-			auth {
-				refresh_token = "refresh_token"
-				access_token = "access_token"
-				realm_id = "realm_id"
-				client_access {
-					client_id = "client_id"
-					client_secret = "client_secret"
-					user_agent = "user_agent"
-					developer_token = "developer_token"
-				}
-			}
-		}`,
-
+		Config: connectorConfigMappingTfConfig,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 				assertEqual(t, connectorMockPostHandler.Interactions, 1)
@@ -1465,6 +1618,41 @@ func TestResourceConnectorEmptyConfigMock(t *testing.T) {
 			Providers: testProviders,
 			CheckDestroy: func(s *terraform.State) error {
 				assertEqual(t, connectorEmptyMockDelete.Interactions, 1)
+				assertEmpty(t, connectorMockData)
+				return nil
+			},
+
+			Steps: []resource.TestStep{
+				step1,
+			},
+		},
+	)
+}
+
+func TestResourceConnectorListsConfigMock(t *testing.T) {
+	step1 := resource.TestStep{
+		Config: connectorConfigListsMappingTfConfig,
+
+		Check: resource.ComposeAggregateTestCheckFunc(
+			func(s *terraform.State) error {
+				assertEqual(t, connectorListsMockPostHandler.Interactions, 1)
+				assertEqual(t, connectorListsMockGetHandler.Interactions, 1)
+				assertNotEmpty(t, connectorMockData)
+				return nil
+			},
+			resource.TestCheckNoResourceAttr("fivetran_connector.test_connector", "config"),
+		),
+	}
+
+	resource.Test(
+		t,
+		resource.TestCase{
+			PreCheck: func() {
+				setupMockClientConnectorResourceListMappingConfig(t)
+			},
+			Providers: testProviders,
+			CheckDestroy: func(s *terraform.State) error {
+				assertEqual(t, connectorListsMockDelete.Interactions, 1)
 				assertEmpty(t, connectorMockData)
 				return nil
 			},

--- a/fivetran/tests/mock/resource_connector_test.go
+++ b/fivetran/tests/mock/resource_connector_test.go
@@ -282,7 +282,7 @@ const (
 
 			"public_key": 			"public_key",
 			"external_id": 			"external_id",
-
+			"group_name":           "group_name",
 			"client_id":             "client_id",
 			"technical_account_id":  "technical_account_id",
 			"organization_id":       "organization_id",
@@ -553,6 +553,7 @@ const (
 			asm_oracle_home = "asm_oracle_home"
 			asm_tns = "asm_tns"
 			sap_user = "sap_user"
+			group_name = "group_name"
 
 			connection_type = "connection_type"
 			sync_mode = "sync_mode"
@@ -1028,6 +1029,7 @@ func setupMockClientConnectorResourceConfigMapping(t *testing.T) {
 			assertKeyExistsAndHasValue(t, config, "api_quota", float64(0))
 			assertKeyExistsAndHasValue(t, config, "daily_api_call_limit", float64(0))
 
+			assertKeyExistsAndHasValue(t, config, "group_name", "group_name")
 			assertKeyExistsAndHasValue(t, config, "pdb_name", "pdb_name")
 			assertKeyExistsAndHasValue(t, config, "agent_host", "agent_host")
 			assertKeyExistsAndHasValue(t, config, "agent_user", "agent_user")


### PR DESCRIPTION
Elements order doesn't matter in collection-like credentials fields. 
We should define all collections in connector config schema as sets.

Most fields are defined as Set<...> on API side so we can't guarantee that consecutive responses will have same elements order.

Task: https://fivetran.height.app/T-415171