### PR TITLE
Fix schema config resource issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.1.4...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.1.5...HEAD)
+
+## [1.1.5](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.1.4...v1.1.5)
+
+## Fixed 
+- Issue with `fivetran_connector_schema_config` resource when column isn't excluded from schema.
 
 ## [1.1.4](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.1.3...v1.1.4)
 

--- a/docs/data-sources/connector.md
+++ b/docs/data-sources/connector.md
@@ -306,8 +306,6 @@ Read-Only:
 	- Service `survicate`: 
 	- Service `trello`: Your TRELLO api key.
 	- Service `uppromote`: Your UpPromote API key.
-- `api_key:api_secret` (String, Sensitive) Field usage depends on `service` value: 
-	- Service `revel`: Your Revel Systems API Key and API Secret.
 - `api_key_api_secret` (String, Sensitive) Field usage depends on `service` value: 
 	- Service `revel`: Your Revel Systems API Key and API Secret.
 - `api_keys` (Set of String, Sensitive) Field usage depends on `service` value: 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ description: |-
 terraform {
   required_providers {
     fivetran = {
-        version = "1.1.4"                            
+        version = "1.1.5"                            
         source = "fivetran/fivetran"
     }
   }

--- a/docs/resources/connector.md
+++ b/docs/resources/connector.md
@@ -394,8 +394,6 @@ Optional:
 	- Service `survicate`: 
 	- Service `trello`: Your TRELLO api key.
 	- Service `uppromote`: Your UpPromote API key.
-- `api_key:api_secret` (String, Sensitive) Field usage depends on `service` value: 
-	- Service `revel`: Your Revel Systems API Key and API Secret.
 - `api_key_api_secret` (String, Sensitive) Field usage depends on `service` value: 
 	- Service `revel`: Your Revel Systems API Key and API Secret.
 - `api_keys` (Set of String, Sensitive) Field usage depends on `service` value: 

--- a/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
@@ -1,0 +1,194 @@
+package mock
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/fivetran/go-fivetran/tests/mock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestResourceSchemaDisableColumnMissingInSchemaResponseMock(t *testing.T) {
+
+	var schemaData map[string]interface{}
+
+	var getHandler *mock.Handler
+	var patchHandler *mock.Handler
+
+	var schemasWoColumnsJsonResponse = `
+{
+	"enable_new_by_default": true,
+	"schemas": {
+		"schema_1": {
+			"name_in_destination": "schema_1",
+			"enabled": true,
+			"tables": {
+				"table_1": {
+					"name_in_destination": "table_1",
+					"sync_mode": "LIVE",
+					"enabled": true,
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_2": {
+							"name_in_destination": "column_2",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"schema_change_handling": "%v"
+}
+	`
+
+	var schemaWithColumnJsonResponse = `
+{
+	"schema_change_handling": "ALLOW_COLUMNS",
+	"schemas": {
+		"schema_1": {
+			"name_in_destination": "schema_1",
+			"enabled": true,
+			"tables": {
+				"table_1": {
+					"name_in_destination": "table_1",
+					"enabled": true,
+					"sync_mode": "SOFT_DELETE",
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_1": {
+							"name_in_destination": "column_1",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_2": {
+							"name_in_destination": "column_2",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+	`
+
+	step1 := resource.TestStep{
+		Config: `
+			resource "fivetran_connector_schema_config" "test_schema" {
+				provider = fivetran-provider
+				connector_id = "connector_id"
+				schema_change_handling = "ALLOW_COLUMNS"
+				schema {
+					name = "schema_1"
+					table {
+						name = "table_1"
+						column {
+							name = "column_1"
+							enabled = false
+						}
+					}
+				}
+			}`,
+
+		Check: resource.ComposeAggregateTestCheckFunc(
+			func(s *terraform.State) error {
+				assertEqual(t, getHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, patchHandler.Interactions, 2) // Update SCM and align schema
+				assertNotEmpty(t, schemaData)                // schema initialised
+				return nil
+			},
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema_change_handling", "ALLOW_COLUMNS"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.0.column.0.enabled", "false"),
+		),
+	}
+
+	resource.Test(
+		t,
+		resource.TestCase{
+			PreCheck: func() {
+				mockClient.Reset()
+				schemaData = nil
+				updateIteration := 0
+
+				getHandler = mockClient.When(http.MethodGet, "/v1/connectors/connector_id/schemas").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						if nil == schemaData {
+							schemaData = createMapFromJsonString(t, fmt.Sprintf(schemasWoColumnsJsonResponse, "ALLOW_ALL"))
+						}
+						return fivetranSuccessResponse(t, req, http.StatusOK, "Success", schemaData), nil
+					},
+				)
+
+				patchHandler = mockClient.When(http.MethodPatch, "/v1/connectors/connector_id/schemas/").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						body := requestBodyToJson(t, req)
+						if updateIteration == 0 {
+							// Check the request
+							assertEqual(t, len(body), 1)
+							assertEqual(t, body["schema_change_handling"], "ALLOW_COLUMNS")
+
+							// create schema structure
+							schemaData = createMapFromJsonString(t, fmt.Sprintf(schemasWoColumnsJsonResponse, "ALLOW_ALL"))
+						}
+
+						if updateIteration == 1 {
+
+							assertKeyExists(t, body, "schemas")
+							schemas := body["schemas"].(map[string]interface{})
+
+							assertKeyExists(t, schemas, "schema_1")
+							schema := schemas["schema_1"].(map[string]interface{})
+
+							assertKeyExists(t, schema, "tables")
+							tables := schema["tables"].(map[string]interface{})
+
+							assertKeyExists(t, tables, "table_1")
+							table := tables["table_1"].(map[string]interface{})
+
+							assertKeyExists(t, table, "columns")
+							columns := table["columns"].(map[string]interface{})
+
+							assertKeyExists(t, columns, "column_1")
+							column := columns["column_1"].(map[string]interface{})
+
+							assertKeyExistsAndHasValue(t, column, "enabled", false)
+
+							// create schema structure
+							schemaData = createMapFromJsonString(t, schemaWithColumnJsonResponse)
+						}
+
+						updateIteration++
+						return fivetranSuccessResponse(t, req, http.StatusOK, "Success", schemaData), nil
+					},
+				)
+			},
+			Providers: testProviders,
+			CheckDestroy: func(s *terraform.State) error {
+				// there is no possibility to destroy schema config - it alsways exists within the connector
+				return nil
+			},
+
+			Steps: []resource.TestStep{
+				step1,
+			},
+		},
+	)
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -16,7 +16,7 @@ description: |-
 terraform {
   required_providers {
     fivetran = {
-        version = "1.1.4"                            
+        version = "1.1.5"                            
         source = "fivetran/fivetran"
     }
   }


### PR DESCRIPTION
If the column is missing in schema config response, but configured in local config we should consider that this column is aligned with policy in upstream config and apply local values for it.