### PR TITLE
README: Remove Beta notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Checkout our [CHANGELOG](CHANGELOG.md) for information about the latest bug fixe
 
 Make sure you read the Fivetran REST API [documentation](https://fivetran.com/docs/rest-api) before using the Provider.
 
-**NOTE**: `terraform-provider-fivetran` is in [BETA](https://en.wikipedia.org/wiki/Software_release_life_cycle#Beta) development stage. Future versions may introduce minor changes and bug fixes. 
-
 ## Known issues
 
 - Version 1.2.5 was broken, please use version 1.2.6.


### PR DESCRIPTION
There is a note that says that our Terraform provider is in Beta, which is not correct. Removed the note.