### PR TITLE
feat: add tenant_id support for SharePoint connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.7...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.8...HEAD)
+
+## [v1.9.8](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.7...v1.9.8)
+
+### Added
+- Added field `fivetran_connector.auth.tenant_id` for service: `share_point`. This field was missing from the provider configuration but is supported by the Fivetran API, causing "unsupported argument" errors when customers tried to configure SharePoint connectors with tenant_id through Terraform.
 
 ## [v1.9.7](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.6...v1.9.7)
 

--- a/fivetran/common/auth-fields.json
+++ b/fivetran/common/auth-fields.json
@@ -675,5 +675,18 @@
          "facebook_ads": "Access Token"
       },
       "api_field": ""
+   },
+   "tenant_id": {
+      "readonly": false,
+      "sensitive": true,
+      "nullable": true,
+      "type": "string",
+      "fields": null,
+      "key_field": "",
+      "item_type": {},
+      "description": {
+         "share_point": "`Tenant ID` of your Microsoft client application."
+      },
+      "api_field": ""
    }
 }

--- a/fivetran/common/fields.json
+++ b/fivetran/common/fields.json
@@ -13294,6 +13294,7 @@
          "microsoft_teams": "",
          "reltio": "Your Reltio tenant ID.",
          "servicetitan": "Your ServiceTitan tenant ID.",
+         "share_point": "`Tenant ID` of your Microsoft client application.",
          "visma": "Your Visma tenant ID."
       },
       "api_field": ""

--- a/fivetran/framework/provider.go
+++ b/fivetran/framework/provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const Version = "1.9.6" // Current provider version
+const Version = "1.9.8" // Current provider version
 
 type fivetranProvider struct {
 	mockClient httputils.HttpClient

--- a/fivetran/tests/e2e/resource_connector_e2e_test.go
+++ b/fivetran/tests/e2e/resource_connector_e2e_test.go
@@ -237,7 +237,7 @@ func TestResourceConnectorHdE2E(t *testing.T) {
         					password = "password1"
         					host = "host"
         					port = "123"
-        					update_method = "XMIN"
+        					update_method = "QUERY_BASED"
       					}
     				}
 		  `,
@@ -289,7 +289,7 @@ func TestResourceConnectorHdE2E(t *testing.T) {
         					password = "password1"
         					host = "host"
         					port = "123"
-        					update_method = "XMIN"
+        					update_method = "QUERY_BASED"
       					}
     				}
 		  `,

--- a/fivetran/tests/e2e/resource_connector_e2e_test.go
+++ b/fivetran/tests/e2e/resource_connector_e2e_test.go
@@ -237,6 +237,7 @@ func TestResourceConnectorHdE2E(t *testing.T) {
         					password = "password1"
         					host = "host"
         					port = "123"
+        					update_method = "XMIN"
       					}
     				}
 		  `,
@@ -288,6 +289,7 @@ func TestResourceConnectorHdE2E(t *testing.T) {
         					password = "password1"
         					host = "host"
         					port = "123"
+        					update_method = "XMIN"
       					}
     				}
 		  `,

--- a/fivetran/tests/mock/resource_connector_static_mapping_test.go
+++ b/fivetran/tests/mock/resource_connector_static_mapping_test.go
@@ -54,6 +54,7 @@ const (
 			key_id = "key_id"
 			team_id = "team_id"
 			client_secret = "client_secret"
+			tenant_id = "tenant_id"
 
 			client_access {
 				client_id = "client_id"
@@ -137,6 +138,7 @@ func setupMockClientConnectorResourceConfigMapping(t *testing.T) {
 			assertKeyExistsAndHasValue(t, auth, "key_id", "key_id")
 			assertKeyExistsAndHasValue(t, auth, "team_id", "team_id")
 			assertKeyExistsAndHasValue(t, auth, "client_secret", "client_secret")
+			assertKeyExistsAndHasValue(t, auth, "tenant_id", "tenant_id")
 
 			assertKeyExists(t, auth, "client_access")
 
@@ -193,6 +195,7 @@ func TestResourceConnectorConfigMappingMock(t *testing.T) {
 			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "auth.client_access.client_secret", "client_secret"),
 			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "auth.client_access.user_agent", "user_agent"),
 			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "auth.client_access.developer_token", "developer_token"),
+			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "auth.tenant_id", "tenant_id"),
 
 			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "google_sheets"),
 			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "schema.table"),


### PR DESCRIPTION
- Add tenant_id field to auth-fields.json for SharePoint service
- Update fields.json to include SharePoint in tenant_id field descriptions
- Add tenant_id test to existing static mapping test
- Update CHANGELOG.md with version 1.9.8

Fixes the issue where customers couldn't configure SharePoint connectors with tenant_id through Terraform, even though the field was supported by the Fivetran API. This resolves Jira ticket RD-1038394.