### PR TITLE
Fix noisy terraform plan output for is_primary_key in connector schem…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.8...HEAD)
 
+## [v1.9.9](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.8...v1.9.9)
+
+### Fixed
+- Fixed noisy `terraform plan` output for `fivetran_connector_schema_config` resource. The `is_primary_key` field in column configuration is now computed-only (read-only), preventing Terraform from showing `+ is_primary_key = (known after apply)` diffs for all columns when making unrelated schema changes. This resolves issue where plans would show hundreds of lines of irrelevant changes. Note: `is_primary_key` can no longer be set in configuration as it's determined by the API based on the source database schema.
+
 ## [v1.9.8](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.7...v1.9.8)
 
 ### Added

--- a/fivetran/framework/core/model/connector_schema_config.go
+++ b/fivetran/framework/core/model/connector_schema_config.go
@@ -265,7 +265,8 @@ func (d *ConnectorSchemaResourceModel) getSchemasMap(schemas []interface{}) base
 							columnElements["hashed"] = types.BoolNull()
 						}
 
-						if _, ok := localColumn["is_primary_key"]; ok && columnMap["is_primary_key"] != nil {
+						// is_primary_key is computed-only, always populate from API response
+						if columnMap["is_primary_key"] != nil {
 							columnElements["is_primary_key"] = types.BoolValue(helpers.StrToBool(columnMap["is_primary_key"].(string)))
 						} else {
 							columnElements["is_primary_key"] = types.BoolNull()
@@ -383,7 +384,8 @@ func (d *ConnectorSchemaResourceModel) getLegacySchemaItems(schemas []interface{
 						} else {
 							columnElements["hashed"] = types.BoolNull()
 						}
-						if _, ok := localColumn["is_primary_key"]; ok && columnMap["is_primary_key"] != nil {
+						// is_primary_key is computed-only, always populate from API response
+						if columnMap["is_primary_key"] != nil {
 							columnElements["is_primary_key"] = types.BoolValue(helpers.StrToBool(columnMap["is_primary_key"].(string)))
 						} else {
 							columnElements["is_primary_key"] = types.BoolNull()

--- a/fivetran/framework/core/schema/connector_schema_config.go
+++ b/fivetran/framework/core/schema/connector_schema_config.go
@@ -21,15 +21,15 @@ func GetConnectorSchemaResourceSchema(ctx context.Context) schema.Schema {
 			"connector_id": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description:   "The unique identifier for the connector within the Fivetran system.",
+				Description: "The unique identifier for the connector within the Fivetran system.",
 			},
 			"group_id": schema.StringAttribute{
-				Optional: true,
-				Description:   "The unique identifier for the Group (Destination) within the Fivetran system.",
+				Optional:    true,
+				Description: "The unique identifier for the Group (Destination) within the Fivetran system.",
 			},
 			"connector_name": schema.StringAttribute{
-				Optional: true,
-				Description:   "The name used both as the connection's name within the Fivetran system and as the source schema's name within your destination.",
+				Optional:    true,
+				Description: "The name used both as the connection's name within the Fivetran system and as the source schema's name within your destination.",
 			},
 			"schema_change_handling": schema.StringAttribute{
 				Optional: true,
@@ -96,9 +96,8 @@ The value defines validation method.
 													Description: "The boolean value specifying whether a column should be hashed.",
 												},
 												"is_primary_key": schema.BoolAttribute{
-													Optional:    true,
 													Computed:    true,
-													Description: "",
+													Description: "Boolean value indicating if the column is a primary key. This field is read-only and computed by the API.",
 												},
 											},
 										},
@@ -196,8 +195,8 @@ func getColumnBlock() schema.SetNestedBlock {
 					Description: "The boolean value specifying whether a column should be hashed.",
 				},
 				"is_primary_key": schema.BoolAttribute{
-					Optional:    true,
-					Description: "",
+					Computed:    true,
+					Description: "Boolean value indicating if the column is a primary key. This field is read-only and computed by the API.",
 				},
 			},
 		},

--- a/fivetran/framework/provider.go
+++ b/fivetran/framework/provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const Version = "1.9.8" // Current provider version
+const Version = "1.9.9" // Current provider version
 
 type fivetranProvider struct {
 	mockClient httputils.HttpClient


### PR DESCRIPTION
…a config

- Changed is_primary_key from Optional+Computed to Computed-only
- Prevents showing '+ is_primary_key = (known after apply)' for all columns
- Updated model to always populate is_primary_key from API responses
- Added comprehensive test (TestResourceSchemaPrimaryKeyComputedMock) with:
  * Validation that is_primary_key is not sent in PATCH requests
  * Plan-only test to verify no drift from is_primary_key values
- Updated CHANGELOG and bumped version to 1.9.9