### PR TITLE
Fixed importing of `fivetran_external_logging` resources, and retrieving log data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.9...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.10...HEAD)
+
+## [v1.9.10](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.9...v1.9.10)
+
+### Fixed
+- Fixed importing of `fivetran_external_logging` resources, and retrieving `fivetran_external_logging` data sources.
 
 ## [v1.9.9](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.8...v1.9.9)
 

--- a/fivetran/framework/core/model/external_logging.go
+++ b/fivetran/framework/core/model/external_logging.go
@@ -111,7 +111,7 @@ func (d *ExternalLogging) ReadFromResponse(ctx context.Context, resp externallog
         if resp.Data.Config.PrimaryKey != "******" {
             config["primary_key"] = types.StringValue(resp.Data.Config.PrimaryKey)
         } else {
-            config["primary_key"] = d.Config.Attributes()["primary_key"]
+            config["primary_key"] = CoalesceToStringNull(d.Config.Attributes()["primary_key"])
         }
     } else {
         config["primary_key"] = types.StringNull()
@@ -121,7 +121,7 @@ func (d *ExternalLogging) ReadFromResponse(ctx context.Context, resp externallog
         if resp.Data.Config.ApiKey != "******" {
             config["api_key"] = types.StringValue(resp.Data.Config.ApiKey)
         } else {
-            config["api_key"] = d.Config.Attributes()["api_key"]
+            config["api_key"] = CoalesceToStringNull(d.Config.Attributes()["api_key"])
         }
     } else {
         config["api_key"] = types.StringNull()
@@ -131,13 +131,21 @@ func (d *ExternalLogging) ReadFromResponse(ctx context.Context, resp externallog
         if resp.Data.Config.Token != "******" {
             config["token"] = types.StringValue(resp.Data.Config.Token)
         } else {
-            config["token"] = d.Config.Attributes()["token"]
+            config["token"] = CoalesceToStringNull(d.Config.Attributes()["token"])
         }
     } else {
         config["token"] = types.StringNull()
     }
 
     d.Config, _ = types.ObjectValue(ExternalLoggingTFConfigType, config)
+}
+
+func CoalesceToStringNull(value attr.Value) attr.Value {
+	if value == nil {
+        return types.StringNull()
+    }
+
+    return value
 }
 
 func (d *ExternalLogging) ReadFromCustomResponse(ctx context.Context, resp externallogging.ExternalLoggingCustomResponse) {

--- a/fivetran/framework/provider.go
+++ b/fivetran/framework/provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const Version = "1.9.9" // Current provider version
+const Version = "1.9.10" // Current provider version
 
 type fivetranProvider struct {
 	mockClient httputils.HttpClient

--- a/fivetran/tests/e2e/resource_external_logging_e2e_test.go
+++ b/fivetran/tests/e2e/resource_external_logging_e2e_test.go
@@ -66,6 +66,12 @@ func TestResourceExternalLoggingE2E(t *testing.T) {
         				primary_key = "PASSWORD"
     				}
 				}
+
+				data "fivetran_external_logging" "data_test_extlog" {
+					provider = fivetran-provider
+
+					id = fivetran_external_logging.test_extlog.id
+				}
 		  `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testFivetranExternalLoggingResourceUpdate(t, "fivetran_external_logging.test_extlog"),
@@ -73,6 +79,12 @@ func TestResourceExternalLoggingE2E(t *testing.T) {
 					resource.TestCheckResourceAttr("fivetran_external_logging.test_extlog", "enabled", "true"),
 					resource.TestCheckResourceAttr("fivetran_external_logging.test_extlog", "config.workspace_id", "workspace_id_1"),
 					resource.TestCheckResourceAttr("fivetran_external_logging.test_extlog", "config.primary_key", "PASSWORD"),
+
+					resource.TestCheckResourceAttr("data.fivetran_external_logging.data_test_extlog", "service", "azure_monitor_log"),
+					resource.TestCheckResourceAttr("data.fivetran_external_logging.data_test_extlog", "enabled", "true"),
+					resource.TestCheckResourceAttr("data.fivetran_external_logging.data_test_extlog", "config.workspace_id", "workspace_id_1"),
+					resource.TestCheckResourceAttr("data.fivetran_external_logging.data_test_extlog", "config.port", "0"),
+					resource.TestCheckResourceAttr("data.fivetran_external_logging.data_test_extlog", "config.enable_ssl", "false"),
 				),
 			},
 		},


### PR DESCRIPTION
Fix for issue #464 

Checked locally