### PR TITLE
A fix for switching a connection from ProxyAgent to SshTunnel. 

### DIFF
--- a/fivetran/framework/resources/connector.go
+++ b/fivetran/framework/resources/connector.go
@@ -321,7 +321,9 @@ func (r *connector) Update(ctx context.Context, req resource.UpdateRequest, resp
 		}
 
 		if !plan.ProxyAgentId.Equal(state.ProxyAgentId) {
-			svc.ProxyAgentId(plan.ProxyAgentId.ValueString())
+			if !plan.ProxyAgentId.IsNull() {
+				svc.ProxyAgentId(plan.ProxyAgentId.ValueString())
+			}
 		}
 
 		if !plan.NetworkingMethod.Equal(state.NetworkingMethod) && plan.NetworkingMethod.ValueString() != "" {


### PR DESCRIPTION
Allow for `proxy_agent_id` be specified as `null` in the TF config.