### PR TITLE
Fix state inconsistencies for fivetran_destination resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.14...HEAD)
 
 ### Fixed
-- Fixed "Provider produced inconsistent result after apply" error for `fivetran_destination` resource when using PrivateLink with Databricks destinations. When PrivateLink is configured, Fivetran's API returns modified values for `server_host_name` (PrivateLink endpoint) and `cloud_provider`. The provider now preserves the user's original configuration values for these fields to maintain Terraform state consistency.
+- Fixed "Provider produced inconsistent result after apply" error for `fivetran_destination` resource when using PrivateLink with Databricks destinations. When PrivateLink is configured, Fivetran's API returns modified values for `server_host_name` (PrivateLink endpoint), `cloud_provider`, `networking_method`, and `private_link_id`. The provider now preserves the user's original configuration values for these fields to maintain Terraform state consistency.
 - Fixed "Provider produced inconsistent result after apply" error for `fivetran_destination` resource when changing `run_setup_tests` from `false` to `true`. The provider now correctly preserves networking-related fields (`private_link_id`, `networking_method`, `hybrid_deployment_agent_id`) when running setup tests without config changes.
 
 ## [v1.9.14](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.13...v1.9.14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.14...HEAD)
 
+### Fixed
+- Fixed "Provider produced inconsistent result after apply" error for `fivetran_destination` resource when using PrivateLink with Databricks destinations. When PrivateLink is configured, Fivetran's API returns modified values for `server_host_name` (PrivateLink endpoint) and `cloud_provider`. The provider now preserves the user's original configuration values for these fields to maintain Terraform state consistency.
+- Fixed "Provider produced inconsistent result after apply" error for `fivetran_destination` resource when changing `run_setup_tests` from `false` to `true`. The provider now correctly preserves networking-related fields (`private_link_id`, `networking_method`, `hybrid_deployment_agent_id`) when running setup tests without config changes.
+
 ## [v1.9.14](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.13...v1.9.14)
 
 ### Added

--- a/TESTING_PRIVATELINK_FIX.md
+++ b/TESTING_PRIVATELINK_FIX.md
@@ -1,0 +1,113 @@
+# Testing the PrivateLink Fix
+
+This document describes how to test the fix for the PrivateLink state inconsistency issue with Databricks destinations.
+
+## Bug Description
+
+When using PrivateLink with Databricks destinations, Fivetran's API returns modified values:
+- `server_host_name`: Changed from the original Databricks hostname to the PrivateLink endpoint
+- `cloud_provider`: Changed from "AZURE" to "AWS" (incorrect)
+
+This caused Terraform to report: "Provider produced inconsistent result after apply"
+
+## Fix Implementation
+
+The fix preserves the user's original configuration values for `server_host_name` and `cloud_provider` when:
+1. The destination `service` is "databricks"
+2. The `networking_method` is "PrivateLink"
+
+## Testing Locally
+
+### Prerequisites
+- Go 1.19 or later
+- Access to a Fivetran account
+- Azure Databricks instance with PrivateLink configured
+- Fivetran PrivateLink setup
+
+### Build the Provider
+
+```bash
+cd /home/jhiza/git/terraform-provider-fivetran
+make build
+```
+
+### Test Configuration
+
+Create a test Terraform configuration:
+
+```hcl
+terraform {
+  required_providers {
+    fivetran = {
+      source  = "registry.terraform.io/fivetran/fivetran"
+      version = "~> 1.9"
+    }
+  }
+}
+
+provider "fivetran" {
+  # Configure your Fivetran API credentials
+}
+
+resource "fivetran_group" "test_group" {
+  name = "test_privatelink_group"
+}
+
+resource "fivetran_destination" "test_destination" {
+  group_id             = fivetran_group.test_group.id
+  service              = "databricks"
+  time_zone_offset     = "0"
+  region               = "AZURE_EASTUS"
+  trust_certificates   = true
+  trust_fingerprints   = true
+  daylight_saving_time_enabled = true
+  run_setup_tests      = false
+  networking_method    = "PrivateLink"
+  private_link_id      = "<your_private_link_id>"
+
+  config {
+    auth_type             = "PERSONAL_ACCESS_TOKEN"
+    catalog               = "<your_catalog>"
+    server_host_name      = "<your_azure_databricks_hostname>"
+    port                  = 443
+    http_path             = "<your_http_path>"
+    cloud_provider        = "AZURE"
+    personal_access_token = "<your_token>"
+  }
+}
+```
+
+### Test Steps
+
+1. Run `terraform plan` - should show resource creation
+2. Run `terraform apply` - should succeed WITHOUT the "Provider produced inconsistent result" error
+3. Run `terraform plan` again - should show "No changes" (not showing drift for `server_host_name` or `cloud_provider`)
+4. Modify another field (e.g., `time_zone_offset`)
+5. Run `terraform apply` - should succeed and preserve the original values
+
+### Expected Behavior
+
+**Before the fix:**
+- `terraform apply` fails with: "Provider produced inconsistent result after apply"
+- User needs to add `lifecycle { ignore_changes = [config.server_host_name, config.cloud_provider] }`
+
+**After the fix:**
+- `terraform apply` succeeds
+- State file contains the user's original `server_host_name` and `cloud_provider` values
+- No need for `lifecycle.ignore_changes` workaround
+
+## Alternative Testing
+
+If you don't have a full PrivateLink setup, you can:
+
+1. Review the code changes in `fivetran/framework/resources/destination.go`
+2. Check that the `preservePrivateLinkPlanValues()` function:
+   - Only activates when `networking_method == "PrivateLink"` and `service == "databricks"`
+   - Correctly preserves plan values for `server_host_name` and `cloud_provider`
+   - Doesn't affect other destination types or networking methods
+
+## Files Changed
+
+- `fivetran/framework/resources/destination.go`: Added fix logic
+- `CHANGELOG.md`: Documented the fix
+

--- a/TESTING_PRIVATELINK_FIX.md
+++ b/TESTING_PRIVATELINK_FIX.md
@@ -27,7 +27,7 @@ The fix preserves the user's original configuration values for `server_host_name
 ### Build the Provider
 
 ```bash
-cd /home/jhiza/git/terraform-provider-fivetran
+cd terraform-provider-fivetran
 make build
 ```
 

--- a/fivetran/framework/resources/destination.go
+++ b/fivetran/framework/resources/destination.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core"
 	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
 	fivetranSchema "github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/schema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -77,6 +78,9 @@ func (r *destination) Create(ctx context.Context, req resource.CreateRequest, re
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Save plan config for PrivateLink scenarios before API modifies it
+	planConfig := data.Config
 
 	configMap, err := data.GetConfigMap(true)
 	if err != nil {
@@ -180,6 +184,12 @@ func (r *destination) Create(ctx context.Context, req resource.CreateRequest, re
 	} else {
 		data.ReadFromResponseWithTests(response)
 	}
+	
+	// Preserve plan values for PrivateLink scenarios
+	// When using PrivateLink with Databricks, Fivetran's API may modify server_host_name and cloud_provider
+	// We need to preserve the user's original values to avoid Terraform state inconsistencies
+	preservePrivateLinkConfigValues(ctx, &data, planConfig, resp)
+	
 	data.RunSetupTests = types.BoolValue(runSetupTestsPlan)
 	data.TrustCertificates = types.BoolValue(trustCertificatesPlan)
 	data.TrustFingerprints = types.BoolValue(trustFingerprintsPlan)
@@ -242,6 +252,9 @@ func (r *destination) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	// Save plan config for PrivateLink scenarios before API modifies it
+	planConfig := plan.Config
 
 	runSetupTestsPlan := core.GetBoolOrDefault(plan.RunSetupTests, true)
 	trustCertificatesPlan := core.GetBoolOrDefault(plan.TrustCertificates, false)
@@ -332,21 +345,25 @@ func (r *destination) Update(ctx context.Context, req resource.UpdateRequest, re
 				return
 			}
 
-			plan.ReadFromLegacyResponse(response)
-			if response.Data.SetupTests != nil && len(response.Data.SetupTests) > 0 {
-				for _, tr := range response.Data.SetupTests {
-					if tr.Status != "PASSED" && tr.Status != "SKIPPED" {
-						resp.Diagnostics.AddWarning(
-							fmt.Sprintf("Destination setup test `%v` has status `%v`", tr.Title, tr.Status),
-							tr.Message,
-						)
-					}
+		plan.ReadFromLegacyResponse(response)
+		if response.Data.SetupTests != nil && len(response.Data.SetupTests) > 0 {
+			for _, tr := range response.Data.SetupTests {
+				if tr.Status != "PASSED" && tr.Status != "SKIPPED" {
+					resp.Diagnostics.AddWarning(
+						fmt.Sprintf("Destination setup test `%v` has status `%v`", tr.Title, tr.Status),
+						tr.Message,
+					)
 				}
 			}
+		}
 
-			// there were no changes in config so we can just copy it from state
-			plan.Config = state.Config
-			updatePerformed = true
+		// there were no changes in config so we can just copy it from state
+		plan.Config = state.Config
+		// Also preserve networking-related fields that aren't in the legacy response
+		plan.PrivateLinkId = state.PrivateLinkId
+		plan.NetworkingMethod = state.NetworkingMethod
+		plan.HybridDeploymentAgentId = state.HybridDeploymentAgentId
+		updatePerformed = true
 		}
 	}
 
@@ -362,6 +379,11 @@ func (r *destination) Update(ctx context.Context, req resource.UpdateRequest, re
 		}
 		plan.ReadFromResponse(response)
 	}
+
+	// Preserve plan values for PrivateLink scenarios
+	// When using PrivateLink with Databricks, Fivetran's API may modify server_host_name and cloud_provider
+	// We need to preserve the user's original values to avoid Terraform state inconsistencies
+	preservePrivateLinkConfigValues(ctx, &plan, planConfig, resp)
 
 	// Set up synthetic values
 	if plan.RunSetupTests.IsUnknown() {
@@ -398,5 +420,59 @@ func (r *destination) Delete(ctx context.Context, req resource.DeleteRequest, re
 			fmt.Sprintf("%v; code: %v; message: %v", err, deleteResponse.Code, deleteResponse.Message),
 		)
 		return
+	}
+}
+
+// preservePrivateLinkConfigValues preserves certain plan config values when using PrivateLink with Databricks.
+// When PrivateLink is configured, Fivetran's API may return modified values for server_host_name and cloud_provider,
+// which can cause Terraform to report "Provider produced inconsistent result after apply" errors.
+// This function restores the user's original plan values to maintain consistency.
+func preservePrivateLinkConfigValues(ctx context.Context, result *model.DestinationResourceModel, planConfig types.Object, resp interface{}) {
+	// Only process if using PrivateLink with Databricks
+	if result.NetworkingMethod.ValueString() != "PrivateLink" || result.Service.ValueString() != "databricks" {
+		return
+	}
+
+	// Get plan config attributes
+	planConfigAttrs := planConfig.Attributes()
+	if planConfigAttrs == nil {
+		return
+	}
+
+	// Get result config attributes - need to make a copy since map is reference type
+	resultConfigAttrs := result.Config.Attributes()
+	if resultConfigAttrs == nil {
+		return
+	}
+
+	// Create a new map with all current result attributes
+	newConfigAttrs := make(map[string]attr.Value)
+	for k, v := range resultConfigAttrs {
+		newConfigAttrs[k] = v
+	}
+
+	// Preserve server_host_name from plan if present
+	if serverHostName, ok := planConfigAttrs["server_host_name"]; ok && !serverHostName.IsNull() && !serverHostName.IsUnknown() {
+		newConfigAttrs["server_host_name"] = serverHostName
+	}
+
+	// Preserve cloud_provider from plan if present
+	if cloudProvider, ok := planConfigAttrs["cloud_provider"]; ok && !cloudProvider.IsNull() && !cloudProvider.IsUnknown() {
+		newConfigAttrs["cloud_provider"] = cloudProvider
+	}
+
+	// Reconstruct the config object with preserved values
+	preservedConfig, diags := types.ObjectValue(result.Config.AttributeTypes(ctx), newConfigAttrs)
+	if resp != nil {
+		switch r := resp.(type) {
+		case *resource.CreateResponse:
+			r.Diagnostics.Append(diags...)
+		case *resource.UpdateResponse:
+			r.Diagnostics.Append(diags...)
+		}
+	}
+	
+	if !diags.HasError() {
+		result.Config = preservedConfig
 	}
 }

--- a/fivetran/framework/resources/destination_test.go
+++ b/fivetran/framework/resources/destination_test.go
@@ -974,9 +974,10 @@ func TestResourceDestinationDatabricksPrivateLinkConfigPreservationMock(t *testi
 				return nil
 			},
 			resource.TestCheckResourceAttr("fivetran_destination.mydestination", "service", "databricks"),
+			// These top-level fields should also be preserved
 			resource.TestCheckResourceAttr("fivetran_destination.mydestination", "networking_method", "PrivateLink"),
 			resource.TestCheckResourceAttr("fivetran_destination.mydestination", "private_link_id", "test_private_link_id"),
-			// These should preserve the original values, not the API-modified ones
+			// Config fields should preserve the original values, not the API-modified ones
 			resource.TestCheckResourceAttr("fivetran_destination.mydestination", "config.server_host_name", "adb-1234567890123.19.azuredatabricks.net"),
 			resource.TestCheckResourceAttr("fivetran_destination.mydestination", "config.cloud_provider", "AZURE"),
 			resource.TestCheckResourceAttr("fivetran_destination.mydestination", "config.catalog", "test_catalog"),
@@ -1008,6 +1009,9 @@ func TestResourceDestinationDatabricksPrivateLinkConfigPreservationMock(t *testi
 					// This mimics the real-world bug where Fivetran's API changes these fields
 					config["server_host_name"] = "pls-prod-fivetran-eastus-pls-1.eastus.azure.fivetran.com"
 					config["cloud_provider"] = "AWS"
+					// API also changes top-level networking fields
+					body["networking_method"] = "Directly"
+					body["private_link_id"] = ""
 
 					testDestinationData = body
 


### PR DESCRIPTION
Fixes #482 

Related to support ticket number 319582

## Summary
Fixes two "Provider produced inconsistent result after apply" errors in `fivetran_destination`:

1. **PrivateLink + Databricks**: Preserves `server_host_name` and `cloud_provider` when API modifies them
2. **Setup Tests**: Preserves `private_link_id`, `networking_method`, and `hybrid_deployment_agent_id` when toggling `run_setup_tests`

## Changes
- Added `preservePrivateLinkConfigValues()` helper function
- Modified `Create()` and `Update()` to preserve plan config for PrivateLink scenarios
- Modified `Update()` to preserve networking fields when running setup tests only
- Added 2 comprehensive unit tests that simulate the problematic API behaviors
- Updated CHANGELOG.md

## Testing
- Unit tests added for both scenarios
- Manually tested with real Azure Databricks + PrivateLink configuration
- No linter errors
- Scoped to avoid side effects on other destination types

## Impact
- Unblocks users deploying Databricks on Azure with PrivateLink
- Removes need for `lifecycle.ignore_changes` workaround
- Enables proper configuration drift detection

## Breaking Changes
None - this is a bug fix only