### PR TITLE
RD-1047517: Fix private link resource documentation formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.16...HEAD)
 
+### Documentation
+- Fixed formatting of `config_map` possible values in `fivetran_private_link` resource documentation. All configuration fields now display on separate lines as bullet points instead of rendering as a continuous paragraph.
+
 ## [v1.9.16](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.15...v1.9.16)
 
 ### Fixed

--- a/docs/resources/private_link.md
+++ b/docs/resources/private_link.md
@@ -29,18 +29,18 @@ resource "fivetran_private_link" "test_pl" {
 
 - `config_map` (Map of String) Configuration.
 
-#### Possible values  
--- `connection_service_name` (String): The name of your connection service.
--- `account_url` (String): The URL of your account.
--- `vpce_id` (String): The ID of your Virtual Private Cloud Endpoint.
--- `aws_account_id` (String): The ID of your AWS account.
--- `cluster_identifier` (String): The cluster identifier.
--- `connection_service_id` (String): The ID of your connection service.
--- `workspace_url` (String): The URL of your workspace.
--- `pls_id` (String): The ID of your Azure Private Link service.
--- `sub_resource_name` (String): The name of subresource.
--- `private_dns_regions` (String): Private DNS Regions.
--- `private_connection_service_id` (String): The ID of your connection service.
+#### Possible values
+- `connection_service_name` (String): The name of your connection service.
+- `account_url` (String): The URL of your account.
+- `vpce_id` (String): The ID of your Virtual Private Cloud Endpoint.
+- `aws_account_id` (String): The ID of your AWS account.
+- `cluster_identifier` (String): The cluster identifier.
+- `connection_service_id` (String): The ID of your connection service.
+- `workspace_url` (String): The URL of your workspace.
+- `pls_id` (String): The ID of your Azure Private Link service.
+- `sub_resource_name` (String): The name of subresource.
+- `private_dns_regions` (String): Private DNS Regions.
+- `private_connection_service_id` (String): The ID of your connection service.
 - `name` (String) The private link name within the account. The name must start with a letter or underscore and can only contain letters, numbers, or underscores. Maximum size of name is 23 characters.
 - `region` (String) Data processing location. This is where Fivetran will operate and run computation on data.
 - `service` (String) Service type.


### PR DESCRIPTION
- Fix config_map possible values to display on separate lines
- Change incorrect markdown syntax from -- to - for proper bullet points
- Remove trailing spaces from "Possible values" heading
- Update formatting for 11 configuration fields (connection_service_name, account_url, vpce_id, aws_account_id, cluster_identifier, connection_service_id, workspace_url, pls_id, sub_resource_name, private_dns_regions, private_connection_service_id)