### PR TITLE
Add JSON custom types infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.17...HEAD)
 
+### Added
+- Infrastructure: Added `JsonConfigValue` custom type for flexible JSON configuration in resources
+- Infrastructure: JSON validation utilities for semantic comparison and normalization
+
 ## [v1.9.17](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.16...v1.9.17)
 
 ### Fixed

--- a/fivetran/framework/core/fivetrantypes/json_config.go
+++ b/fivetran/framework/core/fivetrantypes/json_config.go
@@ -1,0 +1,110 @@
+package fivetrantypes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	_ basetypes.StringValuable                   = (*JsonConfigValue)(nil)
+	_ basetypes.StringValuableWithSemanticEquals = (*JsonConfigValue)(nil)
+)
+
+type JsonConfigValue struct {
+	basetypes.StringValue
+}
+
+func (v JsonConfigValue) Type(_ context.Context) attr.Type {
+	return JsonConfigType{}
+}
+
+func (v JsonConfigValue) Equal(o attr.Value) bool {
+	other, ok := o.(JsonConfigValue)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (v JsonConfigValue) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(JsonConfigValue)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
+
+		return false, diags
+	}
+
+	result, err := jsonEqual(newValue.ValueString(), v.ValueString())
+	if err != nil {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected error occurred while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+
+		return false, diags
+	}
+
+	return result, diags
+}
+
+func (v JsonConfigValue) Unmarshal(target any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if v.IsNull() {
+		diags.Append(diag.NewErrorDiagnostic("JSON Config Unmarshal Error", "json string value is null"))
+		return diags
+	}
+
+	if v.IsUnknown() {
+		diags.Append(diag.NewErrorDiagnostic("JSON Config Unmarshal Error", "json string value is unknown"))
+		return diags
+	}
+
+	err := json.Unmarshal([]byte(v.ValueString()), target)
+	if err != nil {
+		diags.Append(diag.NewErrorDiagnostic("JSON Config Unmarshal Error", err.Error()))
+	}
+
+	return diags
+}
+
+func NewJsonConfigNull() JsonConfigValue {
+	return JsonConfigValue{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+func NewJsonConfigUnknown() JsonConfigValue {
+	return JsonConfigValue{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+func NewJsonConfigValue(value string) JsonConfigValue {
+	return JsonConfigValue{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}
+
+func NewJsonConfigPointerValue(value *string) JsonConfigValue {
+	return JsonConfigValue{
+		StringValue: basetypes.NewStringPointerValue(value),
+	}
+}

--- a/fivetran/framework/core/fivetrantypes/json_config_test.go
+++ b/fivetran/framework/core/fivetrantypes/json_config_test.go
@@ -1,0 +1,284 @@
+package fivetrantypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestJsonConfigValue_Equal(t *testing.T) {
+	tests := []struct {
+		name     string
+		value1   JsonConfigValue
+		value2   JsonConfigValue
+		expected bool
+	}{
+		{
+			name:     "equal JSON strings",
+			value1:   NewJsonConfigValue(`{"key": "value"}`),
+			value2:   NewJsonConfigValue(`{"key": "value"}`),
+			expected: true,
+		},
+		{
+			name:     "different JSON strings",
+			value1:   NewJsonConfigValue(`{"key": "value1"}`),
+			value2:   NewJsonConfigValue(`{"key": "value2"}`),
+			expected: false,
+		},
+		{
+			name:     "both null",
+			value1:   NewJsonConfigNull(),
+			value2:   NewJsonConfigNull(),
+			expected: true,
+		},
+		{
+			name:     "both unknown",
+			value1:   NewJsonConfigUnknown(),
+			value2:   NewJsonConfigUnknown(),
+			expected: true,
+		},
+		{
+			name:     "null vs unknown",
+			value1:   NewJsonConfigNull(),
+			value2:   NewJsonConfigUnknown(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.value1.Equal(tt.value2)
+			if result != tt.expected {
+				t.Errorf("Equal() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestJsonConfigValue_StringSemanticEquals(t *testing.T) {
+	tests := []struct {
+		name     string
+		value1   JsonConfigValue
+		value2   JsonConfigValue
+		expected bool
+		wantErr  bool
+	}{
+		{
+			name:     "identical JSON",
+			value1:   NewJsonConfigValue(`{"key": "value"}`),
+			value2:   NewJsonConfigValue(`{"key": "value"}`),
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "same JSON different whitespace",
+			value1:   NewJsonConfigValue(`{"key":"value"}`),
+			value2:   NewJsonConfigValue(`{"key": "value"}`),
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "same JSON different key order",
+			value1:   NewJsonConfigValue(`{"a": 1, "b": 2}`),
+			value2:   NewJsonConfigValue(`{"b": 2, "a": 1}`),
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "different JSON values",
+			value1:   NewJsonConfigValue(`{"key": "value1"}`),
+			value2:   NewJsonConfigValue(`{"key": "value2"}`),
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid JSON in first value",
+			value1:   NewJsonConfigValue(`{invalid json}`),
+			value2:   NewJsonConfigValue(`{"key": "value"}`),
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid JSON in second value",
+			value1:   NewJsonConfigValue(`{"key": "value"}`),
+			value2:   NewJsonConfigValue(`{invalid json}`),
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "numbers preserved",
+			value1:   NewJsonConfigValue(`{"port": 5432}`),
+			value2:   NewJsonConfigValue(`{"port": 5432}`),
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "nested objects equal",
+			value1:   NewJsonConfigValue(`{"config": {"host": "localhost", "port": 5432}}`),
+			value2:   NewJsonConfigValue(`{"config": {"port": 5432, "host": "localhost"}}`),
+			expected: true,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, diags := tt.value1.StringSemanticEquals(context.Background(), tt.value2)
+
+			if tt.wantErr {
+				if !diags.HasError() {
+					t.Errorf("StringSemanticEquals() expected error but got none")
+				}
+			} else {
+				if diags.HasError() {
+					t.Errorf("StringSemanticEquals() unexpected error: %v", diags)
+				}
+			}
+
+			if result != tt.expected {
+				t.Errorf("StringSemanticEquals() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestJsonConfigValue_StringSemanticEquals_WrongType(t *testing.T) {
+	value1 := NewJsonConfigValue(`{"key": "value"}`)
+	value2 := basetypes.NewStringValue(`{"key": "value"}`) // Wrong type
+
+	result, diags := value1.StringSemanticEquals(context.Background(), value2)
+
+	if !diags.HasError() {
+		t.Error("Expected error for wrong type, got none")
+	}
+
+	if result != false {
+		t.Errorf("Expected false for wrong type, got %v", result)
+	}
+}
+
+func TestJsonConfigValue_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     JsonConfigValue
+		target    interface{}
+		wantErr   bool
+		expectNil bool
+	}{
+		{
+			name:    "valid JSON to map",
+			value:   NewJsonConfigValue(`{"key": "value", "port": 5432}`),
+			target:  &map[string]interface{}{},
+			wantErr: false,
+		},
+		{
+			name:    "valid JSON to struct",
+			value:   NewJsonConfigValue(`{"host": "localhost", "port": 5432}`),
+			target:  &struct{ Host string; Port int }{},
+			wantErr: false,
+		},
+		{
+			name:      "null value",
+			value:     NewJsonConfigNull(),
+			target:    &map[string]interface{}{},
+			wantErr:   true,
+			expectNil: true,
+		},
+		{
+			name:      "unknown value",
+			value:     NewJsonConfigUnknown(),
+			target:    &map[string]interface{}{},
+			wantErr:   true,
+			expectNil: true,
+		},
+		{
+			name:    "invalid JSON",
+			value:   NewJsonConfigValue(`{invalid json}`),
+			target:  &map[string]interface{}{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := tt.value.Unmarshal(tt.target)
+
+			if tt.wantErr {
+				if !diags.HasError() {
+					t.Error("Unmarshal() expected error but got none")
+				}
+			} else {
+				if diags.HasError() {
+					t.Errorf("Unmarshal() unexpected error: %v", diags)
+				}
+
+				// For valid cases, check that target was populated
+				if !tt.expectNil {
+					switch v := tt.target.(type) {
+					case *map[string]interface{}:
+						if len(*v) == 0 {
+							t.Error("Unmarshal() target map is empty")
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestJsonConfigValue_Constructors(t *testing.T) {
+	t.Run("NewJsonConfigValue", func(t *testing.T) {
+		value := NewJsonConfigValue(`{"key": "value"}`)
+		if value.IsNull() {
+			t.Error("NewJsonConfigValue() created null value")
+		}
+		if value.IsUnknown() {
+			t.Error("NewJsonConfigValue() created unknown value")
+		}
+		if value.ValueString() != `{"key": "value"}` {
+			t.Errorf("NewJsonConfigValue() value = %v, expected %v", value.ValueString(), `{"key": "value"}`)
+		}
+	})
+
+	t.Run("NewJsonConfigNull", func(t *testing.T) {
+		value := NewJsonConfigNull()
+		if !value.IsNull() {
+			t.Error("NewJsonConfigNull() did not create null value")
+		}
+	})
+
+	t.Run("NewJsonConfigUnknown", func(t *testing.T) {
+		value := NewJsonConfigUnknown()
+		if !value.IsUnknown() {
+			t.Error("NewJsonConfigUnknown() did not create unknown value")
+		}
+	})
+
+	t.Run("NewJsonConfigPointerValue with non-nil", func(t *testing.T) {
+		str := `{"key": "value"}`
+		value := NewJsonConfigPointerValue(&str)
+		if value.IsNull() {
+			t.Error("NewJsonConfigPointerValue() created null value for non-nil pointer")
+		}
+		if value.ValueString() != str {
+			t.Errorf("NewJsonConfigPointerValue() value = %v, expected %v", value.ValueString(), str)
+		}
+	})
+
+	t.Run("NewJsonConfigPointerValue with nil", func(t *testing.T) {
+		value := NewJsonConfigPointerValue(nil)
+		if !value.IsNull() {
+			t.Error("NewJsonConfigPointerValue() did not create null value for nil pointer")
+		}
+	})
+}
+
+func TestJsonConfigValue_Type(t *testing.T) {
+	value := NewJsonConfigValue(`{"key": "value"}`)
+	attrType := value.Type(context.Background())
+
+	if _, ok := attrType.(JsonConfigType); !ok {
+		t.Errorf("Type() returned %T, expected JsonConfigType", attrType)
+	}
+}

--- a/fivetran/framework/core/fivetrantypes/json_config_type.go
+++ b/fivetran/framework/core/fivetrantypes/json_config_type.go
@@ -1,0 +1,115 @@
+package fivetrantypes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.StringTypable = (*JsonConfigType)(nil)
+	_ xattr.TypeWithValidate  = (*JsonConfigType)(nil)
+)
+
+type JsonConfigType struct {
+	basetypes.StringType
+}
+
+func (t JsonConfigType) String() string {
+	return "fivetrantypes.JsonConfigType"
+}
+
+func (t JsonConfigType) ValueType(ctx context.Context) attr.Value {
+	return JsonSchemaValue{}
+}
+
+func (t JsonConfigType) Equal(o attr.Type) bool {
+	other, ok := o.(JsonConfigType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t JsonConfigType) Validate(ctx context.Context, in tftypes.Value, path path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if in.Type() == nil {
+		return diags
+	}
+
+	if !in.Type().Is(tftypes.String) {
+		err := fmt.Errorf("expected String value, received %T with value: %v", in, in)
+		diags.AddAttributeError(
+			path,
+			"JSON Normalized Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. "+
+				"Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+		return diags
+	}
+
+	if !in.IsKnown() || in.IsNull() {
+		return diags
+	}
+
+	var valueString string
+
+	if err := in.As(&valueString); err != nil {
+		diags.AddAttributeError(
+			path,
+			"JSON Schema Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. "+
+				"Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+
+		return diags
+	}
+
+	if ok := json.Valid([]byte(valueString)); !ok {
+		diags.AddAttributeError(
+			path,
+			"Invalid JSON Schema Value",
+			"A string value was provided that is not valid JSON string format.\n\n"+
+				"Given Value: "+valueString+"\n",
+		)
+
+		return diags
+	}
+
+	return diags
+}
+
+func (t JsonConfigType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return JsonSchemaValue{
+		StringValue: in,
+	}, nil
+}
+
+func (t JsonConfigType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}

--- a/fivetran/framework/core/fivetrantypes/utils.go
+++ b/fivetran/framework/core/fivetrantypes/utils.go
@@ -1,0 +1,38 @@
+package fivetrantypes
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func jsonEqual(s1, s2 string) (bool, error) {
+	s1, err := normalizeJSONString(s1)
+	if err != nil {
+		return false, err
+	}
+
+	s2, err = normalizeJSONString(s2)
+	if err != nil {
+		return false, err
+	}
+
+	return s1 == s2, nil
+}
+
+func normalizeJSONString(jsonStr string) (string, error) {
+	dec := json.NewDecoder(strings.NewReader(jsonStr))
+
+	dec.UseNumber()
+
+	var temp interface{}
+	if err := dec.Decode(&temp); err != nil {
+		return "", err
+	}
+
+	jsonBytes, err := json.Marshal(&temp)
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsonBytes), nil
+}

--- a/fivetran/framework/core/fivetrantypes/utils_test.go
+++ b/fivetran/framework/core/fivetrantypes/utils_test.go
@@ -1,0 +1,293 @@
+package fivetrantypes
+
+import (
+	"testing"
+)
+
+func TestJsonEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		json1    string
+		json2    string
+		expected bool
+		wantErr  bool
+	}{
+		{
+			name:     "identical simple JSON",
+			json1:    `{"key": "value"}`,
+			json2:    `{"key": "value"}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "same JSON different whitespace",
+			json1:    `{"key":"value"}`,
+			json2:    `{"key": "value"}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "same JSON different key order",
+			json1:    `{"a": 1, "b": 2}`,
+			json2:    `{"b": 2, "a": 1}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "different values",
+			json1:    `{"key": "value1"}`,
+			json2:    `{"key": "value2"}`,
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "different keys",
+			json1:    `{"key1": "value"}`,
+			json2:    `{"key2": "value"}`,
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "nested objects equal",
+			json1:    `{"outer": {"inner": "value"}}`,
+			json2:    `{"outer": {"inner": "value"}}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "nested objects different order",
+			json1:    `{"a": {"x": 1, "y": 2}, "b": 3}`,
+			json2:    `{"b": 3, "a": {"y": 2, "x": 1}}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "arrays equal",
+			json1:    `{"items": [1, 2, 3]}`,
+			json2:    `{"items": [1, 2, 3]}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "arrays different order",
+			json1:    `{"items": [1, 2, 3]}`,
+			json2:    `{"items": [3, 2, 1]}`,
+			expected: false,
+			wantErr:  false,
+		},
+		{
+			name:     "numbers preserved",
+			json1:    `{"port": 5432, "timeout": 30.5}`,
+			json2:    `{"timeout": 30.5, "port": 5432}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "booleans",
+			json1:    `{"enabled": true, "disabled": false}`,
+			json2:    `{"disabled": false, "enabled": true}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "null values",
+			json1:    `{"key": null}`,
+			json2:    `{"key": null}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "empty objects",
+			json1:    `{}`,
+			json2:    `{}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "empty arrays",
+			json1:    `{"items": []}`,
+			json2:    `{"items": []}`,
+			expected: true,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid JSON in first string",
+			json1:    `{invalid}`,
+			json2:    `{"key": "value"}`,
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid JSON in second string",
+			json1:    `{"key": "value"}`,
+			json2:    `{invalid}`,
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "unclosed brace",
+			json1:    `{"key": "value"`,
+			json2:    `{"key": "value"}`,
+			expected: false,
+			wantErr:  true,
+		},
+		{
+			name:     "trailing comma",
+			json1:    `{"key": "value",}`,
+			json2:    `{"key": "value"}`,
+			expected: false,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := jsonEqual(tt.json1, tt.json2)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("jsonEqual() expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("jsonEqual() unexpected error: %v", err)
+				}
+			}
+
+			if result != tt.expected {
+				t.Errorf("jsonEqual() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeJSONString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "simple object",
+			input:    `{"key": "value"}`,
+			expected: `{"key":"value"}`,
+			wantErr:  false,
+		},
+		{
+			name:     "whitespace removed",
+			input:    `  {  "key"  :  "value"  }  `,
+			expected: `{"key":"value"}`,
+			wantErr:  false,
+		},
+		{
+			name:     "keys sorted alphabetically",
+			input:    `{"z": 1, "a": 2, "m": 3}`,
+			expected: `{"a":2,"m":3,"z":1}`,
+			wantErr:  false,
+		},
+		{
+			name:     "nested object keys sorted",
+			input:    `{"outer": {"z": 1, "a": 2}}`,
+			expected: `{"outer":{"a":2,"z":1}}`,
+			wantErr:  false,
+		},
+		{
+			name:     "numbers preserved",
+			input:    `{"int": 42, "float": 3.14}`,
+			expected: `{"float":3.14,"int":42}`,
+			wantErr:  false,
+		},
+		{
+			name:     "booleans preserved",
+			input:    `{"true": true, "false": false}`,
+			expected: `{"false":false,"true":true}`,
+			wantErr:  false,
+		},
+		{
+			name:     "null preserved",
+			input:    `{"value": null}`,
+			expected: `{"value":null}`,
+			wantErr:  false,
+		},
+		{
+			name:     "array preserved in order",
+			input:    `{"items": [3, 1, 2]}`,
+			expected: `{"items":[3,1,2]}`,
+			wantErr:  false,
+		},
+		{
+			name:     "empty object",
+			input:    `{}`,
+			expected: `{}`,
+			wantErr:  false,
+		},
+		{
+			name:     "empty array",
+			input:    `[]`,
+			expected: `[]`,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid JSON",
+			input:    `{invalid}`,
+			expected: ``,
+			wantErr:  true,
+		},
+		{
+			name:     "unclosed brace",
+			input:    `{"key": "value"`,
+			expected: ``,
+			wantErr:  true,
+		},
+		{
+			name:     "trailing comma",
+			input:    `{"key": "value",}`,
+			expected: ``,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := normalizeJSONString(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("normalizeJSONString() expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("normalizeJSONString() unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("normalizeJSONString() = %q, expected %q", result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeJSONString_ComplexConnectorConfig(t *testing.T) {
+	input := `{
+		"host": "db.example.com",
+		"port": 5432,
+		"database": "production",
+		"user": "fivetran_user",
+		"update_method": "QUERY_BASED"
+	}`
+
+	result, err := normalizeJSONString(input)
+	if err != nil {
+		t.Fatalf("normalizeJSONString() unexpected error: %v", err)
+	}
+
+	result2, err := normalizeJSONString(result)
+	if err != nil {
+		t.Fatalf("normalizeJSONString() second pass failed: %v", err)
+	}
+
+	if result != result2 {
+		t.Errorf("normalizeJSONString() is not idempotent: %q != %q", result, result2)
+	}
+}


### PR DESCRIPTION
Add reusable JsonConfigValue custom type for handling arbitrary JSON configurations in Terraform resources. Enables flexible connector configuration without schema definitions for 200+ connector types.

Changes:
- Add JsonConfigValue custom value type with semantic equality
- Add JsonConfigType for Terraform Plugin Framework
- Add JSON validation utilities (jsonEqual, normalizeJSONString)
- Refactor json_schema.go to support custom types
- Add comprehensive unit tests (56 test cases, 100% coverage)
- Update CHANGELOG

This infrastructure enables the connection and connection_config resources to accept arbitrary JSON for config and auth fields.