### PR TITLE
RD-1175410 RD-1175411: Add configurable_variables to fivetran_transfo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `configurable_variables` computed attribute to `fivetran_quickstart_package` and `fivetran_quickstart_packages` datasources, exposing configurable variable definitions (`type`, `description`, `allowed_values`) keyed by variable name.
+- `configurable_variables` optional/computed attribute to `fivetran_transformation` resource and datasource `transformation_config` block, allowing users to set and read configurable variable values for QUICKSTART transformations.
 
 ## [v1.9.28](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.28...v1.9.27)
 

--- a/fivetran/framework/core/model/transformation.go
+++ b/fivetran/framework/core/model/transformation.go
@@ -2,6 +2,7 @@ package model
 
 import (
     "context"
+    "fmt"
 
     sdk "github.com/fivetran/go-fivetran/transformations"
     "github.com/hashicorp/terraform-plugin-framework/attr"
@@ -41,13 +42,14 @@ var (
     }
 
     configAttrs = map[string]attr.Type{
-        "project_id":           types.StringType,
-        "package_name":         types.StringType,
-        "name":                 types.StringType,
-        "excluded_models":      types.SetType{ElemType: types.StringType},
-        "connection_ids":       types.SetType{ElemType: types.StringType},
-        "steps":                types.ListType{ElemType: types.ObjectType{AttrTypes: stepAttrTypes}},
-        "upgrade_available":    types.BoolType,
+        "project_id":              types.StringType,
+        "package_name":            types.StringType,
+        "name":                    types.StringType,
+        "excluded_models":         types.SetType{ElemType: types.StringType},
+        "connection_ids":          types.SetType{ElemType: types.StringType},
+        "steps":                   types.ListType{ElemType: types.ObjectType{AttrTypes: stepAttrTypes}},
+        "upgrade_available":       types.BoolType,
+        "configurable_variables":  types.MapType{ElemType: types.StringType},
     }
 )
 
@@ -211,6 +213,16 @@ func (d *Transformation) ReadFromResponse(ctx context.Context, resp sdk.Transfor
         configAttrValues["steps"], _ = types.ListValue(stepSetAttrType, subItems)
     } else {
         configAttrValues["steps"] = types.ListNull(stepSetAttrType)
+    }
+
+    if len(resp.Data.TransformationConfig.ConfigurableVariables) > 0 {
+        cvars := map[string]attr.Value{}
+        for k, v := range resp.Data.TransformationConfig.ConfigurableVariables {
+            cvars[k] = types.StringValue(fmt.Sprintf("%v", v))
+        }
+        configAttrValues["configurable_variables"], _ = types.MapValue(types.StringType, cvars)
+    } else {
+        configAttrValues["configurable_variables"] = types.MapNull(types.StringType)
     }
 
     d.Config = types.ObjectValueMust(configAttrs, configAttrValues)

--- a/fivetran/framework/core/model/transformations.go
+++ b/fivetran/framework/core/model/transformations.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/fivetran/go-fivetran/transformations"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -158,22 +159,32 @@ func (d *Transformations) ReadFromResponse(ctx context.Context, resp transformat
 				configAttrValues["excluded_models"] = types.SetNull(types.StringType)
 			}
     
-    		if v.TransformationConfig.Steps != nil {
-		        subItems := []attr.Value{}
-        		for _, sub := range v.TransformationConfig.Steps {
-		            subItem := map[string]attr.Value{}
-        		    subItem["name"] = types.StringValue(sub.Name)
-		            subItem["command"] = types.StringValue(sub.Command)
+		if v.TransformationConfig.Steps != nil {
+			subItems := []attr.Value{}
+			for _, sub := range v.TransformationConfig.Steps {
+				subItem := map[string]attr.Value{}
+				subItem["name"] = types.StringValue(sub.Name)
+				subItem["command"] = types.StringValue(sub.Command)
 
-        		    subObjectValue, _ := types.ObjectValue(stepAttrTypes, subItem)
-		            subItems = append(subItems, subObjectValue)
-        		}
-		        configAttrValues["steps"], _ = types.ListValue(stepSetAttrType, subItems)
-		    } else {
-        		configAttrValues["steps"] = types.ListNull(stepSetAttrType)
-		    }
+				subObjectValue, _ := types.ObjectValue(stepAttrTypes, subItem)
+				subItems = append(subItems, subObjectValue)
+			}
+			configAttrValues["steps"], _ = types.ListValue(stepSetAttrType, subItems)
+		} else {
+			configAttrValues["steps"] = types.ListNull(stepSetAttrType)
+		}
 
-			item["transformation_config"] = types.ObjectValueMust(configAttrs, configAttrValues)
+		if len(v.TransformationConfig.ConfigurableVariables) > 0 {
+			cvars := map[string]attr.Value{}
+			for k, val := range v.TransformationConfig.ConfigurableVariables {
+				cvars[k] = types.StringValue(fmt.Sprintf("%v", val))
+			}
+			configAttrValues["configurable_variables"], _ = types.MapValue(types.StringType, cvars)
+		} else {
+			configAttrValues["configurable_variables"] = types.MapNull(types.StringType)
+		}
+
+		item["transformation_config"] = types.ObjectValueMust(configAttrs, configAttrValues)
 
 			objectValue, _ := types.ObjectValue(elemTypeAttrs, item)
 			items = append(items, objectValue)

--- a/fivetran/framework/core/schema/transformation.go
+++ b/fivetran/framework/core/schema/transformation.go
@@ -155,6 +155,11 @@ func transformationConfigDatasourceSchema() map[string]datasourceSchema.Attribut
 				},
 			},
 		},
+		"configurable_variables": datasourceSchema.MapAttribute{
+			Computed:    true,
+			ElementType: basetypes.StringType{},
+			Description: "Map of configurable variable values for the Quickstart transformation, keyed by variable name.",
+		},
 	}
 }
 
@@ -204,6 +209,12 @@ func transformationConfigResourceSchema() map[string]resourceSchema.Attribute {
 					},
 				},
 			},
+		},
+		"configurable_variables": resourceSchema.MapAttribute{
+			Optional:    true,
+			Computed:    true,
+			ElementType: basetypes.StringType{},
+			Description: "Map of configurable variable values for the Quickstart transformation, keyed by variable name.",
 		},
 	}
 }

--- a/fivetran/framework/datasources/transformation_test.go
+++ b/fivetran/framework/datasources/transformation_test.go
@@ -68,7 +68,11 @@ func setupMockClienttransformationDataSourceMappingTest(t *testing.T) {
         "excluded_model1",
         "excluded_model2"
       ],
-      "upgrade_available": true
+      "upgrade_available": true,
+      "configurable_variables": {
+        "start_date": "2020-01-01",
+        "use_full_refresh": "true"
+      }
     }
   }`
   tfmock.MockClient().Reset()
@@ -116,6 +120,8 @@ func TestDataSourcetransformationMappingMock(t *testing.T) {
             resource.TestCheckResourceAttr("data.fivetran_transformation.transformation", "transformation_config.excluded_models.0", "excluded_model1"),
             resource.TestCheckResourceAttr("data.fivetran_transformation.transformation", "transformation_config.excluded_models.1", "excluded_model2"),
             resource.TestCheckResourceAttr("data.fivetran_transformation.transformation", "transformation_config.upgrade_available", "true"),
+            resource.TestCheckResourceAttr("data.fivetran_transformation.transformation", "transformation_config.configurable_variables.start_date", "2020-01-01"),
+            resource.TestCheckResourceAttr("data.fivetran_transformation.transformation", "transformation_config.configurable_variables.use_full_refresh", "true"),
             resource.TestCheckResourceAttr("data.fivetran_transformation.transformation", "schedule.smart_syncing", "true"),
             resource.TestCheckResourceAttr("data.fivetran_transformation.transformation", "schedule.interval", "60"),
             resource.TestCheckResourceAttr("data.fivetran_transformation.transformation", "schedule.schedule_type", "schedule_type"),

--- a/fivetran/framework/datasources/transformations_test.go
+++ b/fivetran/framework/datasources/transformations_test.go
@@ -94,7 +94,10 @@ const (
       "excluded_models": [
         "excluded_model2"
       ],
-      "upgrade_available": true
+      "upgrade_available": true,
+      "configurable_variables": {
+        "start_date": "2020-01-01"
+      }
     }
   }
     ],
@@ -158,6 +161,7 @@ func TestDataSourcetransformationsMappingMock(t *testing.T) {
       resource.TestCheckResourceAttr("data.fivetran_transformations.transformation", "transformations.1.transformation_config.connection_ids.0", "connection_id2"),
       resource.TestCheckResourceAttr("data.fivetran_transformations.transformation", "transformations.1.transformation_config.excluded_models.0", "excluded_model2"),
       resource.TestCheckResourceAttr("data.fivetran_transformations.transformation", "transformations.1.transformation_config.upgrade_available", "true"),
+      resource.TestCheckResourceAttr("data.fivetran_transformations.transformation", "transformations.1.transformation_config.configurable_variables.start_date", "2020-01-01"),
       resource.TestCheckResourceAttr("data.fivetran_transformations.transformation", "transformations.1.schedule.smart_syncing", "true"),
       resource.TestCheckResourceAttr("data.fivetran_transformations.transformation", "transformations.1.schedule.interval", "602"),
       resource.TestCheckResourceAttr("data.fivetran_transformations.transformation", "transformations.1.schedule.schedule_type", "schedule_type2"),

--- a/fivetran/framework/resources/transformation.go
+++ b/fivetran/framework/resources/transformation.go
@@ -172,6 +172,21 @@ func (r *transformation) Create(ctx context.Context, req resource.CreateRequest,
 			config.ExcludedModels(evars)
 		}
 
+		if !configAttributes["configurable_variables"].IsUnknown() && !configAttributes["configurable_variables"].IsNull() {
+			if transformationType != "QUICKSTART" {
+				resp.Diagnostics.AddError(
+					"Unable to Create Transformation Resource.",
+					fmt.Sprintf("The parameter `%v` can be set only for QUICKSTART type transformation", "transformation_config.configurable_variables"),
+				)
+				return
+			}
+			cvars := map[string]interface{}{}
+			for k, v := range configAttributes["configurable_variables"].(basetypes.MapValue).Elements() {
+				cvars[k] = v.(basetypes.StringValue).ValueString()
+			}
+			config.ConfigurableVariables(cvars)
+		}
+
 		svc.TransformationConfig(config)
 	}
 
@@ -368,7 +383,7 @@ func (r *transformation) Update(ctx context.Context, req resource.UpdateRequest,
 			config.Steps(evars)
 		}
 
-		if !configPlanAttributes["excluded_models"].IsUnknown() && 
+		if !configPlanAttributes["excluded_models"].IsUnknown() &&
 		!configPlanAttributes["excluded_models"].IsNull() &&
 		!configStateAttributes["excluded_models"].(basetypes.SetValue).Equal(configPlanAttributes["excluded_models"].(basetypes.SetValue)) {
 			if state.ProjectType.ValueString() != "QUICKSTART" {
@@ -386,6 +401,24 @@ func (r *transformation) Update(ctx context.Context, req resource.UpdateRequest,
 
 			hasChanges = true
 			config.ExcludedModels(evars)
+		}
+
+		if !configPlanAttributes["configurable_variables"].IsUnknown() &&
+		!configPlanAttributes["configurable_variables"].IsNull() &&
+		!configStateAttributes["configurable_variables"].(basetypes.MapValue).Equal(configPlanAttributes["configurable_variables"].(basetypes.MapValue)) {
+			if state.ProjectType.ValueString() != "QUICKSTART" {
+				resp.Diagnostics.AddError(
+					"Unable to Update Transformation Resource.",
+					fmt.Sprintf("The parameter `%v` can be set only for QUICKSTART type transformation", "transformation_config.configurable_variables"),
+				)
+				return
+			}
+			cvars := map[string]interface{}{}
+			for k, v := range configPlanAttributes["configurable_variables"].(basetypes.MapValue).Elements() {
+				cvars[k] = v.(basetypes.StringValue).ValueString()
+			}
+			hasChanges = true
+			config.ConfigurableVariables(cvars)
 		}
 
 		if hasChanges {

--- a/fivetran/framework/resources/transformation_test.go
+++ b/fivetran/framework/resources/transformation_test.go
@@ -147,7 +147,11 @@ var (
       "excluded_models": [
         "excluded_model1","excluded_model2"
       ],
-      "upgrade_available": true
+      "upgrade_available": true,
+      "configurable_variables": {
+        "start_date": "2020-01-01",
+        "use_full_refresh": "true"
+      }
     }
   }`
 
@@ -187,7 +191,11 @@ var (
       "excluded_models": [
         "excluded_model1","excluded_model2"
       ],
-      "upgrade_available": true
+      "upgrade_available": true,
+      "configurable_variables": {
+        "start_date": "2020-01-01",
+        "use_full_refresh": "true"
+      }
     }
   }`
 )
@@ -300,6 +308,10 @@ func setupMockClientTransformationQuickstartResource(t *testing.T) {
             tfmock.AssertEqual(t, len(excludedModels), 2)
             tfmock.AssertEqual(t, excludedModels[0], "excluded_model1")
             tfmock.AssertEqual(t, excludedModels[1], "excluded_model2")
+
+            configurableVars := config["configurable_variables"].(map[string]interface{})
+            tfmock.AssertKeyExistsAndHasValue(t, configurableVars, "start_date", "2020-01-01")
+            tfmock.AssertKeyExistsAndHasValue(t, configurableVars, "use_full_refresh", "true")
 
             tfmock.AssertKeyExists(t, body, "schedule")
             schedule := body["schedule"].(map[string]interface{})
@@ -541,6 +553,10 @@ func TestResourceTransformationQuickstartMock(t *testing.T) {
                 package_name = "package_name"
                 connection_ids = ["connection_id1", "connection_id2"]
                 excluded_models = ["excluded_model1", "excluded_model2"]
+                configurable_variables = {
+                    start_date       = "2020-01-01"
+                    use_full_refresh = "true"
+                }
             }
         }
         `,
@@ -564,6 +580,8 @@ func TestResourceTransformationQuickstartMock(t *testing.T) {
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.excluded_models.0", "excluded_model1"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.excluded_models.1", "excluded_model2"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.upgrade_available", "true"),
+            resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.configurable_variables.start_date", "2020-01-01"),
+            resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.configurable_variables.use_full_refresh", "true"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "schedule.smart_syncing", "true"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "schedule.interval", "601"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "schedule.schedule_type", "schedule_type1"),
@@ -596,6 +614,10 @@ func TestResourceTransformationQuickstartMock(t *testing.T) {
                 package_name = "package_name"
                 connection_ids = ["connection_id1", "connection_id2"]
                 excluded_models = ["excluded_model1", "excluded_model2"]
+                configurable_variables = {
+                    start_date       = "2020-01-01"
+                    use_full_refresh = "true"
+                }
             }
         }
         `,
@@ -619,6 +641,8 @@ func TestResourceTransformationQuickstartMock(t *testing.T) {
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.excluded_models.0", "excluded_model1"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.excluded_models.1", "excluded_model2"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.upgrade_available", "true"),
+            resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.configurable_variables.start_date", "2020-01-01"),
+            resource.TestCheckResourceAttr("fivetran_transformation.transformation", "transformation_config.configurable_variables.use_full_refresh", "true"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "schedule.smart_syncing", "true"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "schedule.interval", "601"),
             resource.TestCheckResourceAttr("fivetran_transformation.transformation", "schedule.schedule_type", "schedule_type1"),


### PR DESCRIPTION
…rmation resource and datasource

- Add configurable_variables MapAttribute (Optional+Computed) to transformationConfigResourceSchema
- Add configurable_variables MapAttribute (Computed) to transformationConfigDatasourceSchema
- Add configurable_variables to configAttrs in transformation model
- Populate configurable_variables in ReadFromResponse via fmt.Sprintf("%v", v) for interface{} values
- Add configurable_variables write path in Create (QUICKSTART only guard)
- Add configurable_variables write path in Update with state comparison (QUICKSTART only guard)
- Update transformation resource and datasource tests with configurable_variables mock data and assertions
- Update CHANGELOG