### PR TITLE
Fix connector_schema_config import: set connector_id in ImportState

### DIFF
--- a/fivetran/framework/resources/connector_schema_resource.go
+++ b/fivetran/framework/resources/connector_schema_resource.go
@@ -38,6 +38,7 @@ func (r *connectorSchema) Schema(ctx context.Context, req resource.SchemaRequest
 
 func (r *connectorSchema) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_id"), req.ID)...)
 }
 
 func (r *connectorSchema) reloadSchema(ctx context.Context, connectorID string, diag diag.Diagnostics) connections.ConnectionSchemaDetailsResponse {


### PR DESCRIPTION
## Summary

- `ImportState` for `fivetran_connector_schema_config` only sets the `id` attribute via `ImportStatePassthroughID`, but `ReadResource` reads from `connector_id` to construct the API URL
- After import, `ReadResource` calls `/v1/connections//schemas` (empty connector ID), which returns HTML instead of JSON, causing: `invalid character '<' looking for beginning of value`
- Fix: also set `connector_id` from the import ID in `ImportState`

## Reproduction

```hcl
import {
  to = fivetran_connector_schema_config.example
  id = "my_connector_id"
}

resource "fivetran_connector_schema_config" "example" {
  connector_id           = "my_connector_id"
  schema_change_handling = "ALLOW_ALL"
  schemas = { ... }
}
```

```
$ terraform plan
Error: Unable to Read Connector Schema Resource.
Error while retrieving existing schema. invalid character '<' looking for beginning of value
```

## Fix

One-line addition in `ImportState`:

```go
resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connector_id"), req.ID)...)
```

## Test plan

- [ ] Import a `fivetran_connector_schema_config` resource using an `import {}` block
- [ ] Verify `terraform plan` succeeds without the HTML parsing error
- [ ] Verify `terraform import` CLI command still works