### PR TITLE
CI: Install Terraform CLI in testing workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,6 +17,12 @@ jobs:
       with:
         go-version: 1.21
 
+    - name: Set up Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.9.8"
+        terraform_wrapper: false
+
     - name: Build
       run: go build -v ./...
 


### PR DESCRIPTION
- Add hashicorp/setup-terraform@v3 step before Build
- Pin terraform_version to 1.9.8, disable wrapper for raw stdio compat with terraform-plugin-testing
- Fixes CI failures on main and all open PRs caused by expired GPG key in the framework's Terraform CLI auto-download path