### PR TITLE
`fivetran_connector_schema_config` resource - fix schema table columns object was empty, but now null failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ New connection auth fields supported:
 - Added field `fivetran_connector.config.windows_auth_client_private_key` for services: `sql_server`.
 
 ### Fixed
+- `fivetran_connector_schema_config` resource - fixed schema table columns object was empty, but now null failure
 - Better attribution for `fivetran_proxy_agent` resource properties
 
 ## [v1.9.30](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.30...v1.9.29)

--- a/fivetran/framework/core/model/connector_schema_config.go
+++ b/fivetran/framework/core/model/connector_schema_config.go
@@ -278,7 +278,7 @@ func (d *ConnectorSchemaResourceModel) getSchemasMap(schemas []interface{}, isIm
 				}
 				if len(columns) > 0 {
 					tableElements["columns"], _ = types.MapValue(types.ObjectType{AttrTypes: columnsAttrTypes}, columns)
-				} else if localTable["column"] != nil && len(localTable["column"].(map[string]interface{})) == 0 {
+				} else if !localTable["columns_are_null"].(bool) {
 					tableElements["columns"], _ = types.MapValue(types.ObjectType{AttrTypes: columnsAttrTypes}, columns)
 				} else {
 					tableElements["columns"] = types.MapNull(types.ObjectType{AttrTypes: columnsAttrTypes})
@@ -602,6 +602,7 @@ func (d *ConnectorSchemaResourceModel) getSchemas() []interface{} {
 								}
 							}
 							table["column"] = columns
+							table["columns_are_null"] = columnsMap.IsNull()
 						}
 
 					}

--- a/fivetran/framework/core/model/connector_schema_config.go
+++ b/fivetran/framework/core/model/connector_schema_config.go
@@ -278,6 +278,8 @@ func (d *ConnectorSchemaResourceModel) getSchemasMap(schemas []interface{}, isIm
 				}
 				if len(columns) > 0 {
 					tableElements["columns"], _ = types.MapValue(types.ObjectType{AttrTypes: columnsAttrTypes}, columns)
+				} else if localTable["column"] != nil && len(localTable["column"].(map[string]interface{})) == 0 {
+					tableElements["columns"], _ = types.MapValue(types.ObjectType{AttrTypes: columnsAttrTypes}, columns)
 				} else {
 					tableElements["columns"] = types.MapNull(types.ObjectType{AttrTypes: columnsAttrTypes})
 				}

--- a/fivetran/framework/resources/connector_schema_resource.go
+++ b/fivetran/framework/resources/connector_schema_resource.go
@@ -335,23 +335,16 @@ func (r *connectorSchema) Create(ctx context.Context, req resource.CreateRequest
 			)
 			return
 		}
-	}
 
-	// We need to re-read schema
-	schemaResponse, err = client.NewConnectionSchemaDetails().ConnectionID(connectorID).Do(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create Connector Schema Resource.",
-			fmt.Sprintf("Error while reading schema after schema change handling apply. %v; code: %v; message: %v", err, schemaResponse.Code, schemaResponse.Message),
-		)
-		return
-	}
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create Connector Schema Resource.",
-			fmt.Sprintf("Some elements missing in upstream schema. Details: %v", err),
-		)
-		return
+		// We need to re-read schema
+		schemaResponse, err = client.NewConnectionSchemaDetails().ConnectionID(connectorID).Do(ctx)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to Create Connector Schema Resource.",
+				fmt.Sprintf("Error while reading schema after schema change handling apply. %v; code: %v; message: %v", err, schemaResponse.Code, schemaResponse.Message),
+			)
+			return
+		}
 	}
 
 	// read data from response and merge with existing config

--- a/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
@@ -210,7 +210,6 @@ func TestResourceSchemaDisableColumnMissingInSchemaResponseMock(t *testing.T) {
 	)
 }
 
-
 func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 
 	var schemaData map[string]interface{}
@@ -238,31 +237,7 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 			}
 		}
 	}
-}
-`
-
-// 	var schemasWoColumnsJsonResponse = `
-// {
-// 	"enable_new_by_default": true,
-// 	"schemas": {
-// 		"schema_1": {
-// 			"name_in_destination": "schema_1",
-// 			"enabled": true,
-// 			"tables": {
-// 				"table_1": {
-// 					"name_in_destination": "table_1",
-// 					"sync_mode": "LIVE",
-// 					"enabled": true,
-// 					"enabled_patch_settings": {
-// 						"allowed": true
-// 					}
-// 				}
-// 			}
-// 		}
-// 	},
-// 	"schema_change_handling": "%v"
-// }
-// 	`
+}`
 	var schemasWoColumnsJsonResponse = `
 {
 	"enable_new_by_default": true,
@@ -279,8 +254,50 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 						"allowed": true
 					},
 					"columns": {
+						"column_1": {
+							"name_in_destination": "column_1",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
 						"column_2": {
 							"name_in_destination": "column_2",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_3": {
+							"name_in_destination": "column_3",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				},
+				"table_2": {
+					"name_in_destination": "table_2",
+					"sync_mode": "LIVE",
+					"enabled": true,
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_2_1": {
+							"name_in_destination": "column_2_1",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_2_2": {
+							"name_in_destination": "column_2_2",
 							"enabled": true,
 							"hashed": false,
 							"enabled_patch_settings": {
@@ -293,30 +310,7 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 		}
 	},
 	"schema_change_handling": "%v"
-}
-	`
-
-// 	var schemaWithColumnJsonResponse = `
-// {
-// 	"schema_change_handling": "ALLOW_COLUMNS",
-// 	"schemas": {
-// 		"schema_1": {
-// 			"name_in_destination": "schema_1",
-// 			"enabled": true,
-// 			"tables": {
-// 				"table_1": {
-// 					"name_in_destination": "table_1",
-// 					"enabled": true,
-// 					"sync_mode": "SOFT_DELETE",
-// 					"enabled_patch_settings": {
-// 						"allowed": true
-// 					}
-// 				}
-// 			}
-// 		}
-// 	}
-// }
-// 	`
+}`
 	var schemaWithColumnJsonResponse = `
 {
 	"schema_change_handling": "ALLOW_COLUMNS",
@@ -343,6 +337,40 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 						},
 						"column_2": {
 							"name_in_destination": "column_2",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_3": {
+							"name_in_destination": "column_3",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				},
+				"table_2": {
+					"name_in_destination": "table_2",
+					"enabled": true,
+					"sync_mode": "SOFT_DELETE",
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_2_1": {
+							"name_in_destination": "column_2_1",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_2_2": {
+							"name_in_destination": "column_2_2",
 							"enabled": true,
 							"hashed": false,
 							"enabled_patch_settings": {
@@ -354,44 +382,40 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 			}
 		}
 	}
-}
-	`
+}`
 
 	step1 := resource.TestStep{
 		Config: `
 			locals {
 				tables = {
 					"table_1" = {
-						disabled_columns      = ["column_3", "column_2"]
+						name = "table_1"
+						disabled_columns      = ["column_1", "column_2"]
 					}
 					"table_2" = {
-						disabled_columns      = ["column_3", "column_2"]
+						name = "table_2"
+						disabled_columns      = [] # empty list
 					}
 				}
 			}
 
 			resource "fivetran_connector_schema_config" "test_schema" {
 				provider = fivetran-provider
-				
-				connector_id = "connector_id"
+
+				connector_id           = "connector_id"
 				schema_change_handling = "ALLOW_COLUMNS"
 
-				schema {
-					name = "schema_1"
-
-					dynamic "table" {
-						for_each = local.tables
-						iterator = tables
-						content {
-							name      = tables.key
-							sync_mode = "SOFT_DELETE"
-							enabled   = true
-
-							dynamic "column" {
-								for_each = tables.value.disabled_columns
-								content {
-									name    = column.value
-									enabled = false
+				schemas = {
+					"schema_1" = {
+						enabled = true
+						tables = {
+							for table in local.tables : table.name => {
+								enabled   = true
+								sync_mode = "SOFT_DELETE"
+								columns = {
+									for column in table.disabled_columns : column => {
+										enabled = false
+									}
 								}
 							}
 						}
@@ -402,13 +426,21 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 				assertEqual(t, getHandler.Interactions, 3)   // 1 read attempt before reload, 1 read after create
-				assertEqual(t, patchHandler.Interactions, 2) // Update SCM and align schema
+				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
 			},
 			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema_change_handling", "ALLOW_COLUMNS"),
-			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.0.enabled", "true"),
-			// resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.0.column.0.enabled", "false"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_1.enabled", "true"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_1.sync_mode", "SOFT_DELETE"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_2.enabled", "true"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_2.sync_mode", "SOFT_DELETE"),
+
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_1.columns.%", "2"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_1.columns.column_1.enabled", "false"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_1.columns.column_2.enabled", "false"),
+
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_2.columns.%", "0"),
 		),
 	}
 
@@ -439,7 +471,6 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 						body := 
 						requestBodyToJson(t, req)
 
-						assertEqual(t, len(body), 2)
 						assertEqual(t, body["schema_change_handling"], "ALLOW_COLUMNS")
 
 						schemas := assertKeyExists(t, body, "schemas").(map[string]interface{})
@@ -449,17 +480,8 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 						AssertKeyDoesNotExist(t, schema, "enabled")
 						tables := assertKeyExists(t, schema, "tables").(map[string]interface{})
 
-						//table := 
 						assertKeyExists(t, tables, "table_1")
-						//.(map[string]interface{})
-
-						// AssertKeyDoesNotExist(t, table, "columns")
-						//.(map[string]interface{})
-						//AssertKeyDoesNotExist(t, table, "enabled")
-
-						// column := assertKeyExists(t, columns, "column_1").(map[string]interface{})
-
-						// assertKeyExistsAndHasValue(t, column, "enabled", false)
+						assertKeyExists(t, tables, "table_2")
 
 						// create schema structure
 						schemaData = createMapFromJsonString(t, schemaWithColumnJsonResponse)
@@ -470,7 +492,7 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 			},
 			ProtoV6ProviderFactories: ProtoV6ProviderFactories,
 			CheckDestroy: func(s *terraform.State) error {
-				// there is no possibility to destroy schema config - it alsways exists within the connector
+				// there is no possibility to destroy schema config - it always exists within the connector
 				return nil
 			},
 

--- a/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
@@ -135,7 +135,7 @@ func TestResourceSchemaDisableColumnMissingInSchemaResponseMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 3)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, getHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
@@ -425,7 +425,7 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 3)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, getHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
@@ -441,6 +441,296 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_1.columns.column_2.enabled", "false"),
 
 			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.table_2.columns.%", "0"),
+		),
+	}
+
+	resource.Test(
+		t,
+		resource.TestCase{
+			PreCheck: func() {
+				mockClient.Reset()
+				schemaData = nil
+
+				getHandler = mockClient.When(http.MethodGet, "/v1/connections/connector_id/schemas").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						if nil == schemaData {
+							schemaData = createMapFromJsonString(t, fmt.Sprintf(schemasWoColumnsJsonResponse, "ALLOW_ALL"))
+						}
+						return fivetranSuccessResponse(t, req, http.StatusOK, "Success", schemaData), nil
+					},
+				)
+
+				mockClient.When(http.MethodGet, "/v1/connections/connector_id/schemas/schema_1/tables/table_1/columns").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						return fivetranSuccessResponse(t, req, http.StatusOK, "Success", createMapFromJsonString(t, columnsListResponse)), nil
+					},
+				)
+
+				patchHandler = mockClient.When(http.MethodPatch, "/v1/connections/connector_id/schemas").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						body := 
+						requestBodyToJson(t, req)
+
+						assertEqual(t, body["schema_change_handling"], "ALLOW_COLUMNS")
+
+						schemas := assertKeyExists(t, body, "schemas").(map[string]interface{})
+
+						schema := assertKeyExists(t, schemas, "schema_1").(map[string]interface{})
+
+						AssertKeyDoesNotExist(t, schema, "enabled")
+						tables := assertKeyExists(t, schema, "tables").(map[string]interface{})
+
+						assertKeyExists(t, tables, "table_1")
+						assertKeyExists(t, tables, "table_2")
+
+						// create schema structure
+						schemaData = createMapFromJsonString(t, schemaWithColumnJsonResponse)
+
+						return fivetranSuccessResponse(t, req, http.StatusOK, "Success", schemaData), nil
+					},
+				)
+			},
+			ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+			CheckDestroy: func(s *terraform.State) error {
+				// there is no possibility to destroy schema config - it always exists within the connector
+				return nil
+			},
+
+			Steps: []resource.TestStep{
+				step1,
+			},
+		},
+	)
+}
+
+func TestResourceSchemaEmptyColumnsListOldSchemaMock(t *testing.T) {
+
+	var schemaData map[string]interface{}
+
+	var getHandler *mock.Handler
+	var patchHandler *mock.Handler
+
+	var columnsListResponse = `
+{
+	"columns": {
+		"column_1": {
+			"name_in_destination": "column_1",
+			"enabled": true,
+			"hashed": false,
+			"enabled_patch_settings": {
+				"allowed": true
+			}
+		},
+		"column_2": {
+			"name_in_destination": "column_2",
+			"enabled": true,
+			"hashed": false,
+			"enabled_patch_settings": {
+				"allowed": true
+			}
+		}
+	}
+}`
+	var schemasWoColumnsJsonResponse = `
+{
+	"enable_new_by_default": true,
+	"schemas": {
+		"schema_1": {
+			"name_in_destination": "schema_1",
+			"enabled": true,
+			"tables": {
+				"table_1": {
+					"name_in_destination": "table_1",
+					"sync_mode": "LIVE",
+					"enabled": true,
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_1": {
+							"name_in_destination": "column_1",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_2": {
+							"name_in_destination": "column_2",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_3": {
+							"name_in_destination": "column_3",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				},
+				"table_2": {
+					"name_in_destination": "table_2",
+					"sync_mode": "LIVE",
+					"enabled": true,
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_2_1": {
+							"name_in_destination": "column_2_1",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_2_2": {
+							"name_in_destination": "column_2_2",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"schema_change_handling": "%v"
+}`
+	var schemaWithColumnJsonResponse = `
+{
+	"schema_change_handling": "ALLOW_COLUMNS",
+	"schemas": {
+		"schema_1": {
+			"name_in_destination": "schema_1",
+			"enabled": true,
+			"tables": {
+				"table_1": {
+					"name_in_destination": "table_1",
+					"enabled": true,
+					"sync_mode": "SOFT_DELETE",
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_1": {
+							"name_in_destination": "column_1",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_2": {
+							"name_in_destination": "column_2",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_3": {
+							"name_in_destination": "column_3",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				},
+				"table_2": {
+					"name_in_destination": "table_2",
+					"enabled": true,
+					"sync_mode": "SOFT_DELETE",
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_2_1": {
+							"name_in_destination": "column_2_1",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_2_2": {
+							"name_in_destination": "column_2_2",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}`
+
+	step1 := resource.TestStep{
+		Config: `
+			locals {
+				tables = {
+					"table_1" = {
+						name = "table_1"
+						disabled_columns      = ["column_1", "column_2"]
+					}
+					"table_2" = {
+						name = "table_2"
+						disabled_columns      = [] # empty list
+					}
+				}
+			}
+
+			resource "fivetran_connector_schema_config" "test_schema" {
+				provider = fivetran-provider
+
+				connector_id           = "connector_id"
+				schema_change_handling = "ALLOW_COLUMNS"
+
+				schema {
+					name = "schema_1"
+					dynamic "table" {
+						for_each = local.tables
+						iterator = tables
+						content {
+							name      = tables.key
+							sync_mode = "SOFT_DELETE"
+							enabled   = true
+							dynamic "column" {
+								for_each = tables.value.disabled_columns
+								content {
+									name    = column.value
+									enabled = false
+								}
+							}
+						}
+					}
+				}
+			}`,
+
+		Check: resource.ComposeAggregateTestCheckFunc(
+			func(s *terraform.State) error {
+				assertEqual(t, getHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
+				assertNotEmpty(t, schemaData)                // schema initialised
+				return nil
+			},
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema_change_handling", "ALLOW_COLUMNS"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.0.enabled", "true"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.0.sync_mode", "SOFT_DELETE"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.1.enabled", "true"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.1.sync_mode", "SOFT_DELETE"),
 		),
 	}
 

--- a/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
@@ -209,3 +209,274 @@ func TestResourceSchemaDisableColumnMissingInSchemaResponseMock(t *testing.T) {
 		},
 	)
 }
+
+
+func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
+
+	var schemaData map[string]interface{}
+
+	var getHandler *mock.Handler
+	var patchHandler *mock.Handler
+
+	var columnsListResponse = `
+{
+	"columns": {
+		"column_1": {
+			"name_in_destination": "column_1",
+			"enabled": true,
+			"hashed": false,
+			"enabled_patch_settings": {
+				"allowed": true
+			}
+		},
+		"column_2": {
+			"name_in_destination": "column_2",
+			"enabled": true,
+			"hashed": false,
+			"enabled_patch_settings": {
+				"allowed": true
+			}
+		}
+	}
+}
+`
+
+// 	var schemasWoColumnsJsonResponse = `
+// {
+// 	"enable_new_by_default": true,
+// 	"schemas": {
+// 		"schema_1": {
+// 			"name_in_destination": "schema_1",
+// 			"enabled": true,
+// 			"tables": {
+// 				"table_1": {
+// 					"name_in_destination": "table_1",
+// 					"sync_mode": "LIVE",
+// 					"enabled": true,
+// 					"enabled_patch_settings": {
+// 						"allowed": true
+// 					}
+// 				}
+// 			}
+// 		}
+// 	},
+// 	"schema_change_handling": "%v"
+// }
+// 	`
+	var schemasWoColumnsJsonResponse = `
+{
+	"enable_new_by_default": true,
+	"schemas": {
+		"schema_1": {
+			"name_in_destination": "schema_1",
+			"enabled": true,
+			"tables": {
+				"table_1": {
+					"name_in_destination": "table_1",
+					"sync_mode": "LIVE",
+					"enabled": true,
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_2": {
+							"name_in_destination": "column_2",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"schema_change_handling": "%v"
+}
+	`
+
+// 	var schemaWithColumnJsonResponse = `
+// {
+// 	"schema_change_handling": "ALLOW_COLUMNS",
+// 	"schemas": {
+// 		"schema_1": {
+// 			"name_in_destination": "schema_1",
+// 			"enabled": true,
+// 			"tables": {
+// 				"table_1": {
+// 					"name_in_destination": "table_1",
+// 					"enabled": true,
+// 					"sync_mode": "SOFT_DELETE",
+// 					"enabled_patch_settings": {
+// 						"allowed": true
+// 					}
+// 				}
+// 			}
+// 		}
+// 	}
+// }
+// 	`
+	var schemaWithColumnJsonResponse = `
+{
+	"schema_change_handling": "ALLOW_COLUMNS",
+	"schemas": {
+		"schema_1": {
+			"name_in_destination": "schema_1",
+			"enabled": true,
+			"tables": {
+				"table_1": {
+					"name_in_destination": "table_1",
+					"enabled": true,
+					"sync_mode": "SOFT_DELETE",
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_1": {
+							"name_in_destination": "column_1",
+							"enabled": false,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						},
+						"column_2": {
+							"name_in_destination": "column_2",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+	`
+
+	step1 := resource.TestStep{
+		Config: `
+			locals {
+				tables = {
+					"table_1" = {
+						disabled_columns      = ["column_3", "column_2"]
+					}
+					"table_2" = {
+						disabled_columns      = ["column_3", "column_2"]
+					}
+				}
+			}
+
+			resource "fivetran_connector_schema_config" "test_schema" {
+				provider = fivetran-provider
+				
+				connector_id = "connector_id"
+				schema_change_handling = "ALLOW_COLUMNS"
+
+				schema {
+					name = "schema_1"
+
+					dynamic "table" {
+						for_each = local.tables
+						iterator = tables
+						content {
+							name      = tables.key
+							sync_mode = "SOFT_DELETE"
+							enabled   = true
+
+							dynamic "column" {
+								for_each = tables.value.disabled_columns
+								content {
+									name    = column.value
+									enabled = false
+								}
+							}
+						}
+					}
+				}
+			}`,
+
+		Check: resource.ComposeAggregateTestCheckFunc(
+			func(s *terraform.State) error {
+				assertEqual(t, getHandler.Interactions, 3)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, patchHandler.Interactions, 2) // Update SCM and align schema
+				assertNotEmpty(t, schemaData)                // schema initialised
+				return nil
+			},
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema_change_handling", "ALLOW_COLUMNS"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.0.enabled", "true"),
+			// resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema.0.table.0.column.0.enabled", "false"),
+		),
+	}
+
+	resource.Test(
+		t,
+		resource.TestCase{
+			PreCheck: func() {
+				mockClient.Reset()
+				schemaData = nil
+
+				getHandler = mockClient.When(http.MethodGet, "/v1/connections/connector_id/schemas").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						if nil == schemaData {
+							schemaData = createMapFromJsonString(t, fmt.Sprintf(schemasWoColumnsJsonResponse, "ALLOW_ALL"))
+						}
+						return fivetranSuccessResponse(t, req, http.StatusOK, "Success", schemaData), nil
+					},
+				)
+
+				mockClient.When(http.MethodGet, "/v1/connections/connector_id/schemas/schema_1/tables/table_1/columns").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						return fivetranSuccessResponse(t, req, http.StatusOK, "Success", createMapFromJsonString(t, columnsListResponse)), nil
+					},
+				)
+
+				patchHandler = mockClient.When(http.MethodPatch, "/v1/connections/connector_id/schemas").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						body := 
+						requestBodyToJson(t, req)
+
+						assertEqual(t, len(body), 2)
+						assertEqual(t, body["schema_change_handling"], "ALLOW_COLUMNS")
+
+						schemas := assertKeyExists(t, body, "schemas").(map[string]interface{})
+
+						schema := assertKeyExists(t, schemas, "schema_1").(map[string]interface{})
+
+						AssertKeyDoesNotExist(t, schema, "enabled")
+						tables := assertKeyExists(t, schema, "tables").(map[string]interface{})
+
+						//table := 
+						assertKeyExists(t, tables, "table_1")
+						//.(map[string]interface{})
+
+						// AssertKeyDoesNotExist(t, table, "columns")
+						//.(map[string]interface{})
+						//AssertKeyDoesNotExist(t, table, "enabled")
+
+						// column := assertKeyExists(t, columns, "column_1").(map[string]interface{})
+
+						// assertKeyExistsAndHasValue(t, column, "enabled", false)
+
+						// create schema structure
+						schemaData = createMapFromJsonString(t, schemaWithColumnJsonResponse)
+
+						return fivetranSuccessResponse(t, req, http.StatusOK, "Success", schemaData), nil
+					},
+				)
+			},
+			ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+			CheckDestroy: func(s *terraform.State) error {
+				// there is no possibility to destroy schema config - it alsways exists within the connector
+				return nil
+			},
+
+			Steps: []resource.TestStep{
+				step1,
+			},
+		},
+	)
+}

--- a/fivetran/tests/mock/resource_connector_schema_config_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_config_test.go
@@ -510,7 +510,7 @@ func TestResourceEmptyDefaultSchemaMock(t *testing.T) {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 				assertEqual(t, schemaEmptyDefaultReloadHandler.Interactions, 1)
-				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 3)
+				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 2)
 				assertEqual(t, schemaEmptyDefaultPatchHandler.Interactions, 0)
 				assertNotEmpty(t, schemaEmptyDefaultData) // schema initialised
 				return nil
@@ -822,7 +822,7 @@ func TestSyncModeMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 3) // 1 read attempt before reload, 1 read after create
+				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 2) // 1 read attempt before reload, 1 read after create
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)                    // schema initialised
 				return nil
 			},
@@ -934,7 +934,7 @@ func TestConsistentWithUpstreamSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 3)
+				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 2)
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)
 				return nil
 			},
@@ -1032,7 +1032,7 @@ func TestResourceHashedAlignmentSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaHashedAlignmentGetHandler.Interactions, 3)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, schemaHashedAlignmentGetHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, schemaHashedAlignmentPatchHandler.Interactions, 1) // Update hashed for column
 				assertNotEmpty(t, schemaHashedAlignmentData)                      // schema initialised
 				return nil
@@ -1071,7 +1071,7 @@ func TestResourceLockedSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaLockedGetHandler.Interactions, 3)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, schemaLockedGetHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, schemaLockedPatchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaLockedData)                      // schema initialised
 				return nil
@@ -1183,7 +1183,7 @@ func TestConsistentWithUpstreamSchemaMappedMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 3)
+				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 2)
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)
 				return nil
 			},
@@ -1304,7 +1304,7 @@ func TestResourceByGroupIdAndConnectorNameMock(t *testing.T) {
 			func(s *terraform.State) error {
 				assertEqual(t, listConnectionsHandler.Interactions, 1)
 				assertEqual(t, schemaEmptyDefaultReloadHandler.Interactions, 1)
-				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 3)
+				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 2)
 				assertEqual(t, schemaEmptyDefaultPatchHandler.Interactions, 0)
 				assertNotEmpty(t, schemaEmptyDefaultData) // schema initialised
 				return nil
@@ -2931,7 +2931,7 @@ func TestResourceSchemaConsequentGetReturnsLessColumnsMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaGetHandler.Interactions, 3)
+				assertEqual(t, schemaGetHandler.Interactions, 2)
 				assertEqual(t, schemaPatchHandler.Interactions, 0)
 				assertEqual(t, schemaReloadPostHandler.Interactions, 0)
 				return nil
@@ -3554,7 +3554,7 @@ func TestResourceSchemaReloadUsesPreserveModeMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-					assertEqual(t, schemaGetHandler.Interactions, 3)
+					assertEqual(t, schemaGetHandler.Interactions, 2)
 					assertEqual(t, schemaPatchHandler.Interactions, 0)
 					assertEqual(t, schemaReloadPostHandler.Interactions, 0)
 					return nil
@@ -4116,7 +4116,7 @@ func TestResourceSchemaReloadUsesPreserveModeAndGetColumnsOfTablesIndividuallyMo
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-					assertEqual(t, schemaGetHandler.Interactions, 3)
+					assertEqual(t, schemaGetHandler.Interactions, 2)
 					assertEqual(t, schemaPatchHandler.Interactions, 0)
 					assertEqual(t, schemaReloadPostHandler.Interactions, 0)
 					return nil
@@ -4310,7 +4310,7 @@ func TestResourceConnectorSchemaConfigImportMock(t *testing.T) {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 				assertEqual(t, schemaEmptyDefaultReloadHandler.Interactions, 1)
-				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 3)
+				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 2)
 				assertEqual(t, schemaEmptyDefaultPatchHandler.Interactions, 0)
 				assertNotEmpty(t, schemaEmptyDefaultData) // schema initialised
 				return nil

--- a/modules/connector/schema/schema_config.go
+++ b/modules/connector/schema/schema_config.go
@@ -15,7 +15,7 @@ type SchemaConfig struct {
 
 func (c SchemaConfig) ValidateSchemas(
 	connectorId string,
-	schemas map[string]*connections.ConnectionSchemaConfigSchemaResponse,
+	schemas map[string]*connections.ConnectionSchemaConfigSchemaResponse, //upstream
 	client fivetran.Client,
 	ctx context.Context,
 	validateColumns bool) (error, bool) {

--- a/modules/connector/schema/schema_table.go
+++ b/modules/connector/schema/schema_table.go
@@ -283,6 +283,10 @@ func (t _table) toStateObject(sch string, local *_table, diag *diag.Diagnostics,
 			}
 		}
 		result[COLUMN] = columns
+	} else {
+		if local != nil && local.columns != nil {
+			result[COLUMN] = columns
+		}
 	}
 
 	// table has been configured locally OR has columns to include OR table inconsistent by policy (patch allowed)


### PR DESCRIPTION
A fix for #557 