### PR TITLE
Do not fail if upstream returns null in `networking_method` for destination resource 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ New connection auth fields supported:
 - Added field `fivetran_connector.config.windows_auth_client_private_key` for services: `sql_server`.
 
 ### Fixed
+- `fivetran_destination`: do not fail if upstream returns null in `networking_method`
 - Better attribution for `fivetran_proxy_agent` resource properties
 
 ## [v1.9.30](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.30...v1.9.29)

--- a/fivetran/framework/core/model/destination_resource_model.go
+++ b/fivetran/framework/core/model/destination_resource_model.go
@@ -61,6 +61,8 @@ func (d *DestinationResourceModel) SetHybridDeploymentAgentId(value string) {
 func (d *DestinationResourceModel) SetNetworkingMethod(value string) {
 	if value != "" {
 		d.NetworkingMethod = types.StringValue(value)
+	} else {
+		d.NetworkingMethod = types.StringNull()
 	}
 }
 func (d *DestinationResourceModel) SetPrivateLinkId(value string) {

--- a/fivetran/framework/resources/destination_test.go
+++ b/fivetran/framework/resources/destination_test.go
@@ -1593,12 +1593,8 @@ func TestNetworkingMethodNullMock(t *testing.T) {
 					func(req *http.Request) (*http.Response, error) {
 						body := tfmock.RequestBodyToJson(t, req)
 
-						tfmock.AssertKeyExists(t, body, "config")
-
-						config := body["config"].(map[string]interface{})
-						tfmock.AssertKeyExistsAndHasValue(t, config, "bucket", "bucket1")
-
-						tfmock.AssertKeyDoesNotExist(t, config, "external_id")
+						tfmock.AssertKeyExistsAndHasValue(t, body, "region", "GCP_US_WEST1")
+						tfmock.AssertKeyDoesNotExist(t, body, "networking_method")
 
 						testDestinationData = tfmock.CreateMapFromJsonString(t, `
 						{
@@ -1626,7 +1622,7 @@ func TestNetworkingMethodNullMock(t *testing.T) {
 					func(req *http.Request) (*http.Response, error) {
 						testDestinationData = nil
 						response := tfmock.FivetranSuccessResponse(t, req, 200,
-							"Destination with id 'destionation_id' has been deleted", nil)
+							"Destination with id 'destination_id' has been deleted", nil)
 						return response, nil
 					},
 				)

--- a/fivetran/framework/resources/destination_test.go
+++ b/fivetran/framework/resources/destination_test.go
@@ -1514,3 +1514,134 @@ func TestResourceDestinationPrivateLinkChangeMock(t *testing.T) {
 		},
 	)
 }
+
+func TestNetworkingMethodNullMock(t *testing.T) {
+	var testDestinationData map[string]interface{}
+	var destinationMappingDeleteHandler *mock.Handler
+	step1 := resource.TestStep{
+		Config: `
+			resource "fivetran_destination" "mydestination" {
+				provider = fivetran-provider
+				group_id = "group_id"
+				service = "big_query"
+				time_zone_offset = "0"
+				region = "GCP_US_EAST4"
+				run_setup_tests = "false"
+
+				config {
+					project_id = "project_id1"
+        			support_json_type = true
+        			data_set_location = "US"
+				}
+			}`,
+	}
+
+	step2 := resource.TestStep{
+		Config: `
+			resource "fivetran_destination" "mydestination" {
+				provider = fivetran-provider
+				group_id = "group_id"
+				service = "big_query"
+				time_zone_offset = "0"
+				region = "GCP_US_WEST1"
+				run_setup_tests = "false"
+
+				config {
+					project_id = "project_id1"
+        			support_json_type = true
+        			data_set_location = "US"
+				}
+			}`,
+	}
+
+	resource.Test(
+		t,
+		resource.TestCase{
+			PreCheck: func() {
+				tfmock.MockClient().Reset()
+
+				tfmock.MockClient().When(http.MethodGet, "/v1/destinations/group_id").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						return tfmock.FivetranSuccessResponse(t, req, http.StatusOK, "Success", testDestinationData), nil
+					},
+				)
+
+				tfmock.MockClient().When(http.MethodPost, "/v1/destinations").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						testDestinationData = tfmock.CreateMapFromJsonString(t, `
+						{
+							"id":"group_id",
+							"group_id":"group_id",
+							"service":"big_query",
+							"region":"GCP_US_EAST4",
+							"time_zone_offset":"0",
+							"setup_status":"connected",
+							"daylight_saving_time_enabled":true,
+							"config": {
+								"bucket": null,
+								"project_id": "project_id1",
+								"support_json_type": true,
+								"data_set_location": "US"
+							}
+						}
+						`)
+						return tfmock.FivetranSuccessResponse(t, req, http.StatusCreated, "Success", testDestinationData), nil
+					},
+				)
+
+				tfmock.MockClient().When(http.MethodPatch, "/v1/destinations/group_id").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						body := tfmock.RequestBodyToJson(t, req)
+
+						tfmock.AssertKeyExists(t, body, "config")
+
+						config := body["config"].(map[string]interface{})
+						tfmock.AssertKeyExistsAndHasValue(t, config, "bucket", "bucket1")
+
+						tfmock.AssertKeyDoesNotExist(t, config, "external_id")
+
+						testDestinationData = tfmock.CreateMapFromJsonString(t, `
+						{
+							"id":"group_id",
+							"group_id":"group_id",
+							"service":"big_query",
+							"region":"GCP_US_WEST1",
+							"time_zone_offset":"0",
+							"setup_status":"connected",
+							"daylight_saving_time_enabled":true,
+							"config": {
+								"bucket": null,
+								"project_id": "project_id1",
+								"support_json_type": true,
+								"location": "US",
+								"data_set_location": "US"
+							}
+						}
+						`)
+						return tfmock.FivetranSuccessResponse(t, req, http.StatusOK, "Success", testDestinationData), nil
+					},
+				)
+
+				destinationMappingDeleteHandler = tfmock.MockClient().When(http.MethodDelete, "/v1/destinations/group_id").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						testDestinationData = nil
+						response := tfmock.FivetranSuccessResponse(t, req, 200,
+							"Destination with id 'destionation_id' has been deleted", nil)
+						return response, nil
+					},
+				)
+			},
+			ProtoV6ProviderFactories: tfmock.ProtoV6ProviderFactories,
+			CheckDestroy: func(s *terraform.State) error {
+				tfmock.AssertEqual(t, destinationMappingDeleteHandler.Interactions, 1)
+				tfmock.AssertEmpty(t, testDestinationData)
+				return nil
+			},
+
+			Steps: []resource.TestStep{
+				step1,
+				step2,
+			},
+		},
+	)
+}


### PR DESCRIPTION
A fix for #559