### PR TITLE
`fivetran_proxy_agent`: fix regeneration of secrets by updating `regeneration_counter` in Terraform Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ New connection auth fields supported:
 
 ### Fixed
 - Better attribution for `fivetran_proxy_agent` resource properties
+- `fivetran_proxy_agent`: regeneration of secrets by updating `regeneration_counter` in Terraform Config
 
 ## [v1.9.30](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.30...v1.9.29)
 

--- a/fivetran/framework/core/model/proxy_agent_resource_model.go
+++ b/fivetran/framework/core/model/proxy_agent_resource_model.go
@@ -38,7 +38,6 @@ func (d *ProxyAgentResourceModel) SetDisplayName(value string) {
 func (d *ProxyAgentResourceModel) ReadFromResponse(resp proxy.ProxyDetailsResponse) {
 	var model proxyAgentModel = d
 	readProxyAgentFromResponse(model, resp)
-	d.RegenerationCounter = types.Int64Value(d.RegenerationCounter.ValueInt64() + 1)
 	if(d.AuthToken.IsUnknown()){
 		d.AuthToken = types.StringNull()
 	}

--- a/fivetran/framework/core/schema/proxy_agent.go
+++ b/fivetran/framework/core/schema/proxy_agent.go
@@ -59,7 +59,7 @@ func ProxyAgentSchema() core.Schema {
             "regeneration_counter": {
                 ResourceOnly: true,
                 ValueType:    core.Integer,
-                Description:  "Determines whether regenerarion secrets needs to be performed.",
+                Description:  "Determines whether regeneration secrets needs to be performed.",
             },
         },
     }

--- a/fivetran/framework/resources/proxy_agent.go
+++ b/fivetran/framework/resources/proxy_agent.go
@@ -10,6 +10,7 @@ import (
     fivetranSchema "github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/schema"
     "github.com/hashicorp/terraform-plugin-framework/path"
     "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func ProxyAgent() resource.Resource {
@@ -46,10 +47,12 @@ func (r *proxy) Create(ctx context.Context, req resource.CreateRequest, resp *re
 		return
 	}
 
-	var data model.ProxyAgentResourceModel
+	var data, tfConfig model.ProxyAgentResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &tfConfig)...)
+    regenerationCounterIsManagedByConfig := !tfConfig.RegenerationCounter.IsNull() && !tfConfig.RegenerationCounter.IsUnknown()
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -75,13 +78,16 @@ func (r *proxy) Create(ctx context.Context, req resource.CreateRequest, resp *re
 
     if err != nil {
         resp.Diagnostics.AddError(
-            "Unable to Create Proxy Agent Resource.",
+            "Unable to read Proxy Agent Resource after creation.",
             fmt.Sprintf("%v; code: %v", err, readResponse.Code),
         )
         return
     }
 
     data.ReadFromResponse(readResponse)
+	if !regenerationCounterIsManagedByConfig {
+		data.RegenerationCounter = types.Int64Value(data.RegenerationCounter.ValueInt64() + 1)
+	}
     
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -130,10 +136,12 @@ func (r *proxy) Update(ctx context.Context, req resource.UpdateRequest, resp *re
         return
     }
 
-    var plan, state model.ProxyAgentResourceModel
+    var plan, state, tfConfig model.ProxyAgentResourceModel
 
     resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
     resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	resp.Diagnostics.Append(req.Config.Get(ctx, &tfConfig)...)
+    regenerationCounterIsManagedByConfig := !tfConfig.RegenerationCounter.IsNull() && !tfConfig.RegenerationCounter.IsUnknown()
 
     svc := r.GetClient().NewProxyRegenerateSecrets()
     svc.ProxyId(state.Id.ValueString())
@@ -153,13 +161,18 @@ func (r *proxy) Update(ctx context.Context, req resource.UpdateRequest, resp *re
 
     if err != nil {
         resp.Diagnostics.AddError(
-            "Unable to Create Proxy Agent Resource.",
+            "Unable to read Proxy Agent Resource after regenerating secrets during Update.",
             fmt.Sprintf("%v; code: %v", err, readResponse.Code),
         )
         return
     }
 
     state.ReadFromResponse(readResponse)
+	if regenerationCounterIsManagedByConfig {
+        state.RegenerationCounter = plan.RegenerationCounter
+    } else {
+		state.RegenerationCounter = types.Int64Value(state.RegenerationCounter.ValueInt64() + 1)
+	}
     
     resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/fivetran/tests/e2e/resource_proxy_agent_e2e_test.go
+++ b/fivetran/tests/e2e/resource_proxy_agent_e2e_test.go
@@ -68,10 +68,36 @@ func TestResourceProxyAgentUpdateCounterE2E(t *testing.T) {
 					regeneration_counter = 3 # updating counter to trigger regeneration of credentials
             	}`,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testFivetranProxyAgentResourceCreate(t, "fivetran_proxy_agent.test_proxy_agent"),
 					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "display_name", "display_name"),
 					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "group_region", "GCP_US_EAST4"),
 					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "regeneration_counter", "3"),
+				),
+			},
+			{
+				Config: `
+            	resource "fivetran_proxy_agent" "test_proxy_agent" {
+                	provider = fivetran-provider
+
+                 	display_name = "display_name"
+                 	group_region = "GCP_US_EAST4"
+					regeneration_counter = 3
+            	}
+
+				data "fivetran_proxy_agent" "test_proxy_agent_data" {
+					provider = fivetran-provider
+
+					id = fivetran_proxy_agent.test_proxy_agent.id
+				}
+				data "fivetran_proxy_agents" "test_proxy_agents_data" {
+					provider = fivetran-provider
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "display_name", "display_name"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "group_region", "GCP_US_EAST4"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "regeneration_counter", "3"),
+
+					resource.TestCheckResourceAttr("data.fivetran_proxy_agent.test_proxy_agent_data", "display_name", "display_name"),
+					resource.TestCheckResourceAttr("data.fivetran_proxy_agent.test_proxy_agent_data", "group_region", "GCP_US_EAST4"),
 				),
 			},
 			{

--- a/fivetran/tests/e2e/resource_proxy_agent_e2e_test.go
+++ b/fivetran/tests/e2e/resource_proxy_agent_e2e_test.go
@@ -29,7 +29,56 @@ func TestResourceProxyAgentE2E(t *testing.T) {
 					testFivetranProxyAgentResourceCreate(t, "fivetran_proxy_agent.test_proxy_agent"),
 					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "display_name", "display_name"),
 					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "group_region", "GCP_US_EAST4"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "regeneration_counter", "1"),
 				),
+			},
+		},
+	})
+}
+
+func TestResourceProxyAgentUpdateCounterE2E(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() {},
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		CheckDestroy:             testFivetranProxyAgentResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+            	resource "fivetran_proxy_agent" "test_proxy_agent" {
+                	provider = fivetran-provider
+
+                 	display_name = "display_name"
+                 	group_region = "GCP_US_EAST4"
+					regeneration_counter = 2
+            	}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testFivetranProxyAgentResourceCreate(t, "fivetran_proxy_agent.test_proxy_agent"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "display_name", "display_name"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "group_region", "GCP_US_EAST4"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "regeneration_counter", "2"),
+				),
+			},
+			{
+				Config: `
+            	resource "fivetran_proxy_agent" "test_proxy_agent" {
+                	provider = fivetran-provider
+
+                 	display_name = "display_name"
+                 	group_region = "GCP_US_EAST4"
+					regeneration_counter = 3 # updating counter to trigger regeneration of credentials
+            	}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testFivetranProxyAgentResourceCreate(t, "fivetran_proxy_agent.test_proxy_agent"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "display_name", "display_name"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "group_region", "GCP_US_EAST4"),
+					resource.TestCheckResourceAttr("fivetran_proxy_agent.test_proxy_agent", "regeneration_counter", "3"),
+				),
+			},
+			{
+				ResourceName:      "fivetran_proxy_agent.test_proxy_agent",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"client_cert", "client_private_key", "token", "regeneration_counter"},
 			},
 		},
 	})


### PR DESCRIPTION
**Problem**

Updating `fivetran_proxy_agent.regeneration_counter` causes `terraform apply` to fail with
> Error: Provider produced inconsistent result after apply

**Expectation**

Updating `fivetran_proxy_agent.regeneration_counter` successfully regenerates credentials

**Fix**

1. To distinguish whether `regeneration_counter` is managed by Terraform Config (do not auto-increment `regeneration_counter` in this case), or not managed by Terraform Config (auto-increment on credentials regeneration).

2. Do not auto-increment on Read operation.