### PR TITLE
Connection v2 resource skeleton and CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Internal: connector metadata field status helpers for future validation improvements.
+- Internal: metadata-driven connection resource foundations, including dynamic `config` / `auth` handling and lifecycle plumbing. The resource is not registered yet.
 
 ## [v1.9.34](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.34...v1.9.33)
 

--- a/fivetran/framework/core/config_projection.go
+++ b/fivetran/framework/core/config_projection.go
@@ -1,7 +1,8 @@
-package framework
+package core
 
 import (
 	"context"
+	"math/big"
 	"reflect"
 
 	"github.com/fivetran/go-fivetran/metadata"
@@ -47,6 +48,18 @@ func attrToInterface(ctx context.Context, val attr.Value) interface{} {
 		return v.ValueInt64()
 	case types.Float64:
 		return v.ValueFloat64()
+	case types.Number:
+		n := v.ValueBigFloat()
+		if n == nil {
+			return nil
+		}
+		if i, acc := n.Int64(); acc == big.Exact {
+			return i
+		}
+		f, _ := n.Float64()
+		return f
+	case types.Dynamic:
+		return attrToInterface(ctx, v.UnderlyingValue())
 	case types.Object:
 		return convertObjectAttrs(ctx, v.Attributes())
 	case types.Map:
@@ -54,6 +67,8 @@ func attrToInterface(ctx context.Context, val attr.Value) interface{} {
 	case types.List:
 		return convertSliceElems(ctx, v.Elements())
 	case types.Set:
+		return convertSliceElems(ctx, v.Elements())
+	case types.Tuple:
 		return convertSliceElems(ctx, v.Elements())
 	}
 	return nil
@@ -73,6 +88,99 @@ func convertSliceElems(ctx context.Context, elems []attr.Value) []interface{} {
 		result[i] = attrToInterface(ctx, v)
 	}
 	return result
+}
+
+// MapToDynamic converts a map back into a Terraform dynamic object value.
+func MapToDynamic(ctx context.Context, m map[string]interface{}) (types.Dynamic, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if m == nil {
+		return types.DynamicNull(), diags
+	}
+
+	value, _, valueDiags := interfaceToAttrValue(ctx, m)
+	diags.Append(valueDiags...)
+	if diags.HasError() {
+		return types.DynamicNull(), diags
+	}
+
+	return types.DynamicValue(value), diags
+}
+
+func interfaceToAttrValue(ctx context.Context, value interface{}) (attr.Value, attr.Type, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	switch v := value.(type) {
+	case nil:
+		return types.DynamicNull(), types.DynamicType, diags
+	case string:
+		return types.StringValue(v), types.StringType, diags
+	case bool:
+		return types.BoolValue(v), types.BoolType, diags
+	case int:
+		return types.Int64Value(int64(v)), types.Int64Type, diags
+	case int8:
+		return types.Int64Value(int64(v)), types.Int64Type, diags
+	case int16:
+		return types.Int64Value(int64(v)), types.Int64Type, diags
+	case int32:
+		return types.Int64Value(int64(v)), types.Int64Type, diags
+	case int64:
+		return types.Int64Value(v), types.Int64Type, diags
+	case uint:
+		return types.Int64Value(int64(v)), types.Int64Type, diags
+	case uint8:
+		return types.Int64Value(int64(v)), types.Int64Type, diags
+	case uint16:
+		return types.Int64Value(int64(v)), types.Int64Type, diags
+	case uint32:
+		return types.Int64Value(int64(v)), types.Int64Type, diags
+	case uint64:
+		return types.NumberValue(new(big.Float).SetUint64(v)), types.NumberType, diags
+	case float32:
+		return numberValue(float64(v)), types.NumberType, diags
+	case float64:
+		return numberValue(v), types.NumberType, diags
+	case map[string]interface{}:
+		attrTypes := make(map[string]attr.Type, len(v))
+		attrValues := make(map[string]attr.Value, len(v))
+		for key, nested := range v {
+			nestedValue, nestedType, nestedDiags := interfaceToAttrValue(ctx, nested)
+			diags.Append(nestedDiags...)
+			attrTypes[key] = nestedType
+			attrValues[key] = nestedValue
+		}
+		result, resultDiags := types.ObjectValue(attrTypes, attrValues)
+		diags.Append(resultDiags...)
+		return result, types.ObjectType{AttrTypes: attrTypes}, diags
+	case []interface{}:
+		elementTypes := make([]attr.Type, 0, len(v))
+		elementValues := make([]attr.Value, 0, len(v))
+		for _, nested := range v {
+			nestedValue, nestedType, nestedDiags := interfaceToAttrValue(ctx, nested)
+			diags.Append(nestedDiags...)
+			elementTypes = append(elementTypes, nestedType)
+			elementValues = append(elementValues, nestedValue)
+		}
+		result, resultDiags := types.TupleValue(elementTypes, elementValues)
+		diags.Append(resultDiags...)
+		return result, types.TupleType{ElemTypes: elementTypes}, diags
+	}
+
+	diags.AddError("Unsupported dynamic value", "The API returned a dynamic field value the provider does not know how to store in Terraform state.")
+	return types.DynamicNull(), types.DynamicType, diags
+}
+
+func numberValue(value float64) types.Number {
+	f := new(big.Float).SetFloat64(value)
+	if i, acc := f.Int64(); acc == big.Exact {
+		return types.NumberValue(new(big.Float).SetInt64(i))
+	}
+	return types.NumberValue(f)
+}
+
+// ProjectDynamic filters an API read-back (remote) down to managed keys.
+func ProjectDynamic(remote, mask map[string]interface{}, slot *metadata.Property) map[string]interface{} {
+	return project(remote, mask, slot)
 }
 
 // project filters an API read-back (remote) down to the keys the user manages (mask/plan),
@@ -119,6 +227,16 @@ func project(remote, mask map[string]interface{}, slot *metadata.Property) map[s
 		}
 
 		result[key] = remoteVal
+	}
+
+	for key, remoteVal := range remote {
+		if _, inMask := mask[key]; inMask {
+			continue
+		}
+		prop := slotProp(slot, key)
+		if prop != nil && prop.Readonly {
+			result[key] = remoteVal
+		}
 	}
 
 	return result

--- a/fivetran/framework/core/config_projection_test.go
+++ b/fivetran/framework/core/config_projection_test.go
@@ -1,4 +1,4 @@
-package framework
+package core
 
 import (
 	"context"
@@ -84,6 +84,48 @@ func TestDynamicToMap_EmptyStringPreserved(t *testing.T) {
 	}
 }
 
+func TestMapToDynamic_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	input := map[string]interface{}{
+		"bucket":  "b",
+		"enabled": true,
+		"count":   3,
+		"nested": map[string]interface{}{
+			"pattern": "",
+		},
+		"list": []interface{}{"a", "b"},
+	}
+
+	dyn, diags := MapToDynamic(ctx, input)
+	if diags.HasError() {
+		t.Fatalf("MapToDynamic diagnostics: %v", diags)
+	}
+
+	output, diags := DynamicToMap(ctx, dyn)
+	if diags.HasError() {
+		t.Fatalf("DynamicToMap diagnostics: %v", diags)
+	}
+
+	if output["bucket"] != "b" {
+		t.Errorf("bucket: got %v, want b", output["bucket"])
+	}
+	if output["enabled"] != true {
+		t.Errorf("enabled: got %v, want true", output["enabled"])
+	}
+	if output["count"] != int64(3) {
+		t.Errorf("count: got %v (%T), want int64(3)", output["count"], output["count"])
+	}
+	nested := output["nested"].(map[string]interface{})
+	if nested["pattern"] != "" {
+		t.Errorf("nested.pattern: got %v, want empty string", nested["pattern"])
+	}
+	list := output["list"].([]interface{})
+	if len(list) != 2 || list[0] != "a" || list[1] != "b" {
+		t.Errorf("list: got %v, want [a b]", list)
+	}
+}
+
 // --- project ---
 
 func TestProject_NormalFieldTakesRemote(t *testing.T) {
@@ -135,6 +177,21 @@ func TestProject_ReadonlyTakesRemote(t *testing.T) {
 			t.Errorf("readonly: got %v, want server-key (remote stored for reference)", result["public_key"])
 		}
 	})
+}
+
+func TestProject_ReadonlyAbsentFromMaskTakesRemote(t *testing.T) {
+	t.Parallel()
+	slot := makeSlot(map[string]*metadata.Property{
+		"public_key": {Readonly: true},
+	})
+	remote := map[string]interface{}{"public_key": "server-key"}
+	mask := map[string]interface{}{}
+
+	result := project(remote, mask, slot)
+
+	if result["public_key"] != "server-key" {
+		t.Errorf("readonly absent from mask: got %v, want server-key", result["public_key"])
+	}
 }
 
 func TestProject_MissingFromAPI_SetNil(t *testing.T) {

--- a/fivetran/framework/core/core.go
+++ b/fivetran/framework/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/fivetran/go-fivetran"
 	"github.com/hashicorp/terraform-plugin-framework/action"
@@ -23,7 +24,8 @@ import (
 )
 
 type clientContainer struct {
-	client *fivetran.Client
+	client        *fivetran.Client
+	metadataCache *sync.Map
 }
 
 type ProviderDatasource struct {
@@ -40,6 +42,10 @@ type ProviderResource struct {
 
 func (d *clientContainer) GetClient() *fivetran.Client {
 	return d.client
+}
+
+func (d *clientContainer) GetMetadataCache() *sync.Map {
+	return d.metadataCache
 }
 
 func (d *ProviderAction) Configure(ctx context.Context, req action.ConfigureRequest, resp *action.ConfigureResponse) {
@@ -64,6 +70,7 @@ func (d *clientContainer) getClient(diag diag.Diagnostics, data any) {
 		d.client = v
 	case *ProviderResourceData:
 		d.client = v.Client
+		d.metadataCache = v.MetadataCache
 	default:
 		diag.AddError(
 			"Unexpected Resource Configure Type",

--- a/fivetran/framework/core/metadata_cache.go
+++ b/fivetran/framework/core/metadata_cache.go
@@ -1,4 +1,4 @@
-package framework
+package core
 
 import (
 	"context"

--- a/fivetran/framework/core/metadata_cache_test.go
+++ b/fivetran/framework/core/metadata_cache_test.go
@@ -1,4 +1,4 @@
-package framework
+package core
 
 import (
 	"context"
@@ -66,8 +66,8 @@ func TestMetadataCache_HitReturnsCachedValue(t *testing.T) {
 	if m1.ID != "google_sheets" {
 		t.Errorf("unexpected ID: %v", m1.ID)
 	}
-	if got := m1.Config.Properties["spreadsheet_id"].FieldStatus; got != FieldStatusPrivatePreview {
-		t.Errorf("unexpected field status: got %q, want %q", got, FieldStatusPrivatePreview)
+	if got := m1.Config.Properties["spreadsheet_id"].FieldStatus; got != "private_preview" {
+		t.Errorf("unexpected field status: got %q, want %q", got, "private_preview")
 	}
 }
 

--- a/fivetran/framework/core/model/connection_v2_model.go
+++ b/fivetran/framework/core/model/connection_v2_model.go
@@ -21,7 +21,6 @@ type ConnectionV2ResourceModel struct {
 	ServiceVersion  types.String `tfsdk:"service_version"`
 	SyncFrequency   types.Int64  `tfsdk:"sync_frequency"`
 	ScheduleType    types.String `tfsdk:"schedule_type"`
-	Paused          types.Bool   `tfsdk:"paused"`
 	PauseAfterTrial types.Bool   `tfsdk:"pause_after_trial"`
 	DailySyncTime   types.String `tfsdk:"daily_sync_time"`
 
@@ -77,7 +76,6 @@ func ConnectionV2ResourceModelAttrTypes() map[string]attr.Type {
 		"service_version":            types.StringType,
 		"sync_frequency":             types.Int64Type,
 		"schedule_type":              types.StringType,
-		"paused":                     types.BoolType,
 		"pause_after_trial":          types.BoolType,
 		"daily_sync_time":            types.StringType,
 		"proxy_agent_id":             types.StringType,

--- a/fivetran/framework/core/model/connection_v2_model.go
+++ b/fivetran/framework/core/model/connection_v2_model.go
@@ -1,7 +1,16 @@
 package model
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	gfcommon "github.com/fivetran/go-fivetran/common"
+	"github.com/fivetran/go-fivetran/connections"
+	"github.com/fivetran/go-fivetran/metadata"
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -89,4 +98,134 @@ func ConnectionV2ResourceModelAttrTypes() map[string]attr.Type {
 		"trust_fingerprints":         types.BoolType,
 		"status":                     types.ObjectType{AttrTypes: ConnectionV2StatusAttrTypes()},
 	}
+}
+
+func (d *ConnectionV2ResourceModel) ReadFromCreateResponse(ctx context.Context, resp connections.DetailsWithCustomConfigResponse, meta *metadata.ConnectorMetadata, configMask map[string]interface{}) diag.Diagnostics {
+	return d.readFromResponseData(ctx, resp.Data.DetailsResponseDataCommon, resp.Data.Config, meta, configMask)
+}
+
+func (d *ConnectionV2ResourceModel) ReadFromResponse(ctx context.Context, resp connections.DetailsWithCustomConfigNoTestsResponse, meta *metadata.ConnectorMetadata, configMask map[string]interface{}) diag.Diagnostics {
+	return d.readFromResponseData(ctx, resp.Data.DetailsResponseDataCommon, resp.Data.Config, meta, configMask)
+}
+
+func (d *ConnectionV2ResourceModel) ReadFromResponseForImport(ctx context.Context, resp connections.DetailsWithCustomConfigNoTestsResponse, meta *metadata.ConnectorMetadata) diag.Diagnostics {
+	return d.readFromResponseData(ctx, resp.Data.DetailsResponseDataCommon, resp.Data.Config, meta, resp.Data.Config)
+}
+
+func (d *ConnectionV2ResourceModel) readFromResponseData(ctx context.Context, data connections.DetailsResponseDataCommon, config map[string]interface{}, meta *metadata.ConnectorMetadata, configMask map[string]interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	d.Id = types.StringValue(data.ID)
+	d.Name = types.StringValue(data.Schema)
+	d.ConnectedBy = stringValueOrNull(data.ConnectedBy)
+	d.CreatedAt = timeValueOrNull(data.CreatedAt)
+	d.GroupId = types.StringValue(data.GroupID)
+	d.Service = types.StringValue(data.Service)
+
+	d.SucceededAt = timeValueOrNull(data.SucceededAt)
+	d.FailedAt = timeValueOrNull(data.FailedAt)
+	d.ServiceVersion = intPointerStringValue(data.ServiceVersion)
+	d.SyncFrequency = intPointerInt64Value(data.SyncFrequency)
+	d.ScheduleType = stringValueOrNull(data.ScheduleType)
+	d.PauseAfterTrial = boolPointerValue(data.PauseAfterTrial)
+	d.DailySyncTime = stringValueOrNull(data.DailySyncTime)
+
+	d.ProxyAgentId = stringValueOrNull(data.ProxyAgentId)
+	d.NetworkingMethod = stringValueOrNull(data.NetworkingMethod)
+	d.HybridDeploymentAgentId = stringValueOrNull(data.HybridDeploymentAgentId)
+	d.PrivateLinkId = stringValueOrNull(data.PrivateLinkId)
+
+	d.DataDelaySensitivity = stringValueOrNull(data.DataDelaySensitivity)
+	d.DataDelayThreshold = intPointerInt64Value(data.DataDelayThreshold)
+	d.Status = connectionV2StatusValue(data.Status)
+
+	configSlot := (*metadata.Property)(nil)
+	if meta != nil {
+		configSlot = &meta.Config
+	}
+	projectedConfig := core.ProjectDynamic(config, configMask, configSlot)
+	dynamicConfig, dynamicDiags := core.MapToDynamic(ctx, projectedConfig)
+	diags.Append(dynamicDiags...)
+	if !diags.HasError() {
+		d.Config = dynamicConfig
+	}
+
+	return diags
+}
+
+func stringValueOrNull(value string) types.String {
+	if value == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(value)
+}
+
+func timeValueOrNull(value time.Time) types.String {
+	if value.IsZero() {
+		return types.StringNull()
+	}
+	return types.StringValue(value.String())
+}
+
+func intPointerStringValue(value *int) types.String {
+	if value == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(fmt.Sprintf("%v", *value))
+}
+
+func intPointerInt64Value(value *int) types.Int64 {
+	if value == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(int64(*value))
+}
+
+func boolPointerValue(value *bool) types.Bool {
+	if value == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*value)
+}
+
+func connectionV2ReadCommonResponse(r gfcommon.CommonResponse) attr.Value {
+	result, _ := types.ObjectValue(ConnectionV2CodeMessageAttrTypes(),
+		map[string]attr.Value{
+			"code":    types.StringValue(r.Code),
+			"message": types.StringValue(r.Message),
+		})
+	return result
+}
+
+func connectionV2StatusValue(status connections.StatusResponse) types.Object {
+	codeMessageType := types.ObjectType{
+		AttrTypes: ConnectionV2CodeMessageAttrTypes(),
+	}
+
+	warnings := make([]attr.Value, 0, len(status.Warnings))
+	for _, w := range status.Warnings {
+		warnings = append(warnings, connectionV2ReadCommonResponse(w))
+	}
+
+	tasks := make([]attr.Value, 0, len(status.Tasks))
+	for _, t := range status.Tasks {
+		tasks = append(tasks, connectionV2ReadCommonResponse(t))
+	}
+
+	warningsValue, _ := types.SetValue(codeMessageType, warnings)
+	tasksValue, _ := types.SetValue(codeMessageType, tasks)
+
+	result, _ := types.ObjectValue(
+		ConnectionV2StatusAttrTypes(),
+		map[string]attr.Value{
+			"setup_state":        stringValueOrNull(status.SetupState),
+			"is_historical_sync": boolPointerValue(status.IsHistoricalSync),
+			"sync_state":         stringValueOrNull(status.SyncState),
+			"update_state":       stringValueOrNull(status.UpdateState),
+			"warnings":           warningsValue,
+			"tasks":              tasksValue,
+		},
+	)
+
+	return result
 }

--- a/fivetran/framework/core/model/connection_v2_model.go
+++ b/fivetran/framework/core/model/connection_v2_model.go
@@ -1,0 +1,94 @@
+package model
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ConnectionV2ResourceModel struct {
+	Id          types.String `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	ConnectedBy types.String `tfsdk:"connected_by"`
+	CreatedAt   types.String `tfsdk:"created_at"`
+	GroupId     types.String `tfsdk:"group_id"`
+	Service     types.String `tfsdk:"service"`
+
+	Config types.Dynamic `tfsdk:"config"`
+	Auth   types.Dynamic `tfsdk:"auth"`
+
+	SucceededAt     types.String `tfsdk:"succeeded_at"`
+	FailedAt        types.String `tfsdk:"failed_at"`
+	ServiceVersion  types.String `tfsdk:"service_version"`
+	SyncFrequency   types.Int64  `tfsdk:"sync_frequency"`
+	ScheduleType    types.String `tfsdk:"schedule_type"`
+	Paused          types.Bool   `tfsdk:"paused"`
+	PauseAfterTrial types.Bool   `tfsdk:"pause_after_trial"`
+	DailySyncTime   types.String `tfsdk:"daily_sync_time"`
+
+	ProxyAgentId            types.String `tfsdk:"proxy_agent_id"`
+	NetworkingMethod        types.String `tfsdk:"networking_method"`
+	HybridDeploymentAgentId types.String `tfsdk:"hybrid_deployment_agent_id"`
+	PrivateLinkId           types.String `tfsdk:"private_link_id"`
+
+	DataDelaySensitivity types.String `tfsdk:"data_delay_sensitivity"`
+	DataDelayThreshold   types.Int64  `tfsdk:"data_delay_threshold"`
+
+	RunSetupTests     types.Bool `tfsdk:"run_setup_tests"`
+	TrustCertificates types.Bool `tfsdk:"trust_certificates"`
+	TrustFingerprints types.Bool `tfsdk:"trust_fingerprints"`
+
+	Status types.Object `tfsdk:"status"`
+}
+
+func ConnectionV2CodeMessageAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"code":    types.StringType,
+		"message": types.StringType,
+	}
+}
+
+func ConnectionV2StatusAttrTypes() map[string]attr.Type {
+	codeMessageType := types.ObjectType{
+		AttrTypes: ConnectionV2CodeMessageAttrTypes(),
+	}
+
+	return map[string]attr.Type{
+		"setup_state":        types.StringType,
+		"is_historical_sync": types.BoolType,
+		"sync_state":         types.StringType,
+		"update_state":       types.StringType,
+		"tasks":              types.SetType{ElemType: codeMessageType},
+		"warnings":           types.SetType{ElemType: codeMessageType},
+	}
+}
+
+func ConnectionV2ResourceModelAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                         types.StringType,
+		"name":                       types.StringType,
+		"connected_by":               types.StringType,
+		"created_at":                 types.StringType,
+		"group_id":                   types.StringType,
+		"service":                    types.StringType,
+		"config":                     types.DynamicType,
+		"auth":                       types.DynamicType,
+		"succeeded_at":               types.StringType,
+		"failed_at":                  types.StringType,
+		"service_version":            types.StringType,
+		"sync_frequency":             types.Int64Type,
+		"schedule_type":              types.StringType,
+		"paused":                     types.BoolType,
+		"pause_after_trial":          types.BoolType,
+		"daily_sync_time":            types.StringType,
+		"proxy_agent_id":             types.StringType,
+		"networking_method":          types.StringType,
+		"hybrid_deployment_agent_id": types.StringType,
+		"private_link_id":            types.StringType,
+		"data_delay_sensitivity":     types.StringType,
+		"data_delay_threshold":       types.Int64Type,
+		"run_setup_tests":            types.BoolType,
+		"trust_certificates":         types.BoolType,
+		"trust_fingerprints":         types.BoolType,
+		"status":                     types.ObjectType{AttrTypes: ConnectionV2StatusAttrTypes()},
+	}
+}

--- a/fivetran/framework/core/model/connection_v2_model_test.go
+++ b/fivetran/framework/core/model/connection_v2_model_test.go
@@ -1,0 +1,84 @@
+package model_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestConnectionV2ResourceModelTfsdkShape(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	config, diags := types.ObjectValue(
+		map[string]attr.Type{
+			"schema": types.StringType,
+			"table":  types.StringType,
+		},
+		map[string]attr.Value{
+			"schema": types.StringValue("app"),
+			"table":  types.StringValue("events"),
+		},
+	)
+	if diags.HasError() {
+		t.Fatalf("building config: %v", diags)
+	}
+
+	input := model.ConnectionV2ResourceModel{
+		Id:                      types.StringValue("connection_id"),
+		Name:                    types.StringValue("app"),
+		ConnectedBy:             types.StringValue("user_id"),
+		CreatedAt:               types.StringValue("2026-06-18T10:00:00Z"),
+		GroupId:                 types.StringValue("group_id"),
+		Service:                 types.StringValue("postgres"),
+		Config:                  types.DynamicValue(config),
+		Auth:                    types.DynamicNull(),
+		SucceededAt:             types.StringValue("2026-06-18T11:00:00Z"),
+		FailedAt:                types.StringNull(),
+		ServiceVersion:          types.StringValue("1"),
+		SyncFrequency:           types.Int64Value(60),
+		ScheduleType:            types.StringValue("auto"),
+		Paused:                  types.BoolValue(true),
+		PauseAfterTrial:         types.BoolValue(false),
+		DailySyncTime:           types.StringNull(),
+		ProxyAgentId:            types.StringNull(),
+		NetworkingMethod:        types.StringValue("Directly"),
+		HybridDeploymentAgentId: types.StringNull(),
+		PrivateLinkId:           types.StringNull(),
+		DataDelaySensitivity:    types.StringValue("NORMAL"),
+		DataDelayThreshold:      types.Int64Value(0),
+		RunSetupTests:           types.BoolValue(false),
+		TrustCertificates:       types.BoolValue(false),
+		TrustFingerprints:       types.BoolValue(false),
+		Status:                  types.ObjectNull(model.ConnectionV2StatusAttrTypes()),
+	}
+
+	var object types.Object
+	diags = tfsdk.ValueFrom(ctx, input, types.ObjectType{AttrTypes: model.ConnectionV2ResourceModelAttrTypes()}, &object)
+	if diags.HasError() {
+		t.Fatalf("ValueFrom diagnostics: %v", diags)
+	}
+
+	var output model.ConnectionV2ResourceModel
+	diags = tfsdk.ValueAs(ctx, object, &output)
+	if diags.HasError() {
+		t.Fatalf("ValueAs diagnostics: %v", diags)
+	}
+
+	if output.Service.ValueString() != "postgres" {
+		t.Fatalf("unexpected service: got %q", output.Service.ValueString())
+	}
+	if output.Config.IsNull() || output.Config.IsUnknown() {
+		t.Fatal("expected config dynamic value to round-trip")
+	}
+	if !output.Auth.IsNull() {
+		t.Fatal("expected null auth dynamic value to round-trip")
+	}
+	if output.Status.IsUnknown() {
+		t.Fatal("expected status object to keep a known null value")
+	}
+}

--- a/fivetran/framework/core/model/connection_v2_model_test.go
+++ b/fivetran/framework/core/model/connection_v2_model_test.go
@@ -42,7 +42,6 @@ func TestConnectionV2ResourceModelTfsdkShape(t *testing.T) {
 		ServiceVersion:          types.StringValue("1"),
 		SyncFrequency:           types.Int64Value(60),
 		ScheduleType:            types.StringValue("auto"),
-		Paused:                  types.BoolValue(true),
 		PauseAfterTrial:         types.BoolValue(false),
 		DailySyncTime:           types.StringNull(),
 		ProxyAgentId:            types.StringNull(),

--- a/fivetran/framework/core/schema/connection_v2.go
+++ b/fivetran/framework/core/schema/connection_v2.go
@@ -1,0 +1,226 @@
+package schema
+
+import (
+	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+func ConnectionV2ResourceSchema() resourceSchema.Schema {
+	return resourceSchema.Schema{
+		Attributes: ConnectionV2ResourceAttributes(),
+		Version:    0,
+	}
+}
+
+func ConnectionV2ResourceAttributes() map[string]resourceSchema.Attribute {
+	attributes := map[string]resourceSchema.Attribute{
+		"id": resourceSchema.StringAttribute{
+			Computed:    true,
+			Description: "The unique identifier for the connection within the Fivetran system.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"name": resourceSchema.StringAttribute{
+			Computed:    true,
+			Description: "The name used both as the connection's name within the Fivetran system and as the source schema's name within your destination.",
+		},
+		"connected_by": resourceSchema.StringAttribute{
+			Computed:    true,
+			Description: "The unique identifier of the user who created the connection in your account.",
+		},
+		"created_at": resourceSchema.StringAttribute{
+			Computed:    true,
+			Description: "The timestamp of the time the connection was created in your account.",
+		},
+		"group_id": resourceSchema.StringAttribute{
+			Required:    true,
+			Description: "The unique identifier for the Group (Destination) within the Fivetran system.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"service": resourceSchema.StringAttribute{
+			Required:    true,
+			Description: "The connection service type (e.g., `postgres`, `mysql`, `s3`, `snowflake`). See Fivetran connection types documentation for available services.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"config": resourceSchema.DynamicAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Service-specific connection configuration. The accepted fields are defined by connector metadata at runtime.",
+		},
+		"auth": resourceSchema.DynamicAttribute{
+			Optional:    true,
+			Computed:    true,
+			Sensitive:   true,
+			Description: "Service-specific authorization configuration. The accepted fields are defined by connector metadata at runtime.",
+		},
+		"succeeded_at": resourceSchema.StringAttribute{
+			Computed:    true,
+			Description: "The timestamp of the time the connection sync succeeded last time.",
+		},
+		"failed_at": resourceSchema.StringAttribute{
+			Computed:    true,
+			Description: "The timestamp of the time the connection sync failed last time.",
+		},
+		"service_version": resourceSchema.StringAttribute{
+			Computed:    true,
+			Description: "The connection type version within the Fivetran system.",
+		},
+		"sync_frequency": resourceSchema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "The connection sync frequency in minutes.",
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
+		},
+		"schedule_type": resourceSchema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "The connection schedule configuration type. Supported values: auto, manual.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"paused": resourceSchema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Specifies whether the connection is paused.",
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"pause_after_trial": resourceSchema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Specifies whether the connection should be paused after the free trial period has ended.",
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"daily_sync_time": resourceSchema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "The optional parameter that defines the sync start time when the sync frequency is already set or being set by the current request to 1440.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"proxy_agent_id": resourceSchema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "The ID of the proxy agent to use. Required when `networking_method` is `ProxyAgent`.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"networking_method": resourceSchema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "The networking method for the connection. Possible values: `Directly`, `SshTunnel`, `ProxyAgent`, `PrivateLink`.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"hybrid_deployment_agent_id": resourceSchema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "The hybrid deployment agent ID that refers to the controller created for the group the connection belongs to.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"private_link_id": resourceSchema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "The private link ID. Required when `networking_method` is `PrivateLink`.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"data_delay_sensitivity": resourceSchema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "The level of data delay notification threshold. Possible values: LOW, NORMAL, HIGH, CUSTOM, SYNC_FREQUENCY.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"data_delay_threshold": resourceSchema.Int64Attribute{
+			Optional:    true,
+			Computed:    true,
+			Description: "Custom sync delay notification threshold in minutes. This parameter is only used when data_delay_sensitivity is set to CUSTOM.",
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
+		},
+		"run_setup_tests": resourceSchema.BoolAttribute{
+			Optional:    true,
+			Description: "Whether to run setup tests when creating or updating the connection. This is a plan-only attribute.",
+		},
+		"trust_certificates": resourceSchema.BoolAttribute{
+			Optional:    true,
+			Description: "Specifies whether Fivetran should trust certificates automatically. This is a plan-only attribute.",
+		},
+		"trust_fingerprints": resourceSchema.BoolAttribute{
+			Optional:    true,
+			Description: "Specifies whether Fivetran should trust SSH fingerprints automatically. This is a plan-only attribute.",
+		},
+		"status": connectionV2StatusAttribute(),
+	}
+
+	return attributes
+}
+
+func connectionV2StatusAttribute() resourceSchema.SingleNestedAttribute {
+	return resourceSchema.SingleNestedAttribute{
+		Computed:    true,
+		Description: "The current connection status.",
+		Attributes: map[string]resourceSchema.Attribute{
+			"setup_state": resourceSchema.StringAttribute{
+				Computed:    true,
+				Description: "The current setup state of the connection.",
+			},
+			"is_historical_sync": resourceSchema.BoolAttribute{
+				Computed:    true,
+				Description: "Whether the connection should be triggered to re-sync all historical data on the next scheduled sync.",
+			},
+			"sync_state": resourceSchema.StringAttribute{
+				Computed:    true,
+				Description: "The current sync state of the connection.",
+			},
+			"update_state": resourceSchema.StringAttribute{
+				Computed:    true,
+				Description: "The current data update state of the connection.",
+			},
+			"tasks":    connectionV2CodeMessageSetAttribute("The collection of tasks for the connection."),
+			"warnings": connectionV2CodeMessageSetAttribute("The collection of warnings for the connection."),
+		},
+	}
+}
+
+func connectionV2CodeMessageSetAttribute(description string) resourceSchema.SetNestedAttribute {
+	return resourceSchema.SetNestedAttribute{
+		Computed:    true,
+		Description: description,
+		NestedObject: resourceSchema.NestedAttributeObject{
+			Attributes: map[string]resourceSchema.Attribute{
+				"code": resourceSchema.StringAttribute{
+					Computed:    true,
+					Description: "Code.",
+				},
+				"message": resourceSchema.StringAttribute{
+					Computed:    true,
+					Description: "Message.",
+				},
+			},
+		},
+	}
+}

--- a/fivetran/framework/core/schema/connection_v2.go
+++ b/fivetran/framework/core/schema/connection_v2.go
@@ -57,7 +57,6 @@ func ConnectionV2ResourceAttributes() map[string]resourceSchema.Attribute {
 		},
 		"auth": resourceSchema.DynamicAttribute{
 			Optional:    true,
-			Computed:    true,
 			Sensitive:   true,
 			Description: "Service-specific authorization configuration. The accepted fields are defined by connector metadata at runtime.",
 		},

--- a/fivetran/framework/core/schema/connection_v2.go
+++ b/fivetran/framework/core/schema/connection_v2.go
@@ -89,14 +89,6 @@ func ConnectionV2ResourceAttributes() map[string]resourceSchema.Attribute {
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
-		"paused": resourceSchema.BoolAttribute{
-			Optional:    true,
-			Computed:    true,
-			Description: "Specifies whether the connection is paused.",
-			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
-			},
-		},
 		"pause_after_trial": resourceSchema.BoolAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/fivetran/framework/resources/connection_v2.go
+++ b/fivetran/framework/resources/connection_v2.go
@@ -2,10 +2,18 @@ package resources
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
+	"github.com/fivetran/go-fivetran/common"
+	"github.com/fivetran/go-fivetran/connections"
+	"github.com/fivetran/go-fivetran/metadata"
 	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core"
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
 	fivetranSchema "github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func ConnectionV2() resource.Resource {
@@ -17,6 +25,7 @@ type connectionV2 struct {
 }
 
 var _ resource.ResourceWithConfigure = &connectionV2{}
+var _ resource.ResourceWithImportState = &connectionV2{}
 
 func (r *connectionV2) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_connection_v2"
@@ -26,30 +35,392 @@ func (r *connectionV2) Schema(ctx context.Context, req resource.SchemaRequest, r
 	resp.Schema = fivetranSchema.ConnectionV2ResourceSchema()
 }
 
-func (r *connectionV2) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	resp.Diagnostics.AddError(
-		"fivetran_connection_v2 is not registered",
-		"The resource skeleton is present for development, but CRUD is implemented in a follow-up change and the resource is not registered with the provider yet.",
+func (r *connectionV2) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	if r.GetClient() == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Fivetran Client",
+			"Please report this issue to the provider developers.",
+		)
+		return
+	}
+
+	details, err := r.GetClient().NewConnectionDetails().ConnectionID(req.ID).DoCustom(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Import Connection V2 Resource.",
+			fmt.Sprintf("%v; code: %v; message: %v", err, details.Code, details.Message),
+		)
+		return
+	}
+
+	meta, err := r.connectorMetadata(ctx, details.Data.Service)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Fetch Connection Metadata.",
+			fmt.Sprintf("Unable to fetch metadata for service %q: %v", details.Data.Service, err),
+		)
+		return
+	}
+
+	data := model.ConnectionV2ResourceModel{
+		Auth:              types.DynamicNull(),
+		RunSetupTests:     types.BoolValue(false),
+		TrustCertificates: types.BoolValue(false),
+		TrustFingerprints: types.BoolValue(false),
+	}
+
+	resp.Diagnostics.Append(data.ReadFromResponseForImport(ctx, details, meta)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.AddWarning(
+		"fivetran_connection_v2 import requires HCL review",
+		"Terraform imported the connection using API-visible config fields. Add the matching fivetran_connection_v2 resource block to your configuration and restore any sensitive auth values because the API does not return auth secrets.",
 	)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *connectionV2) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	if r.GetClient() == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Fivetran Client",
+			"Please report this issue to the provider developers.",
+		)
+		return
+	}
+
+	var data model.ConnectionV2ResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	meta, err := r.connectorMetadata(ctx, data.Service.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Fetch Connection Metadata.",
+			fmt.Sprintf("Unable to fetch metadata for service %q: %v", data.Service.ValueString(), err),
+		)
+		return
+	}
+
+	configMap, authMap := r.dynamicPlanMaps(ctx, data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	runSetupTestsPlan := core.GetBoolOrDefault(data.RunSetupTests, false)
+	trustCertificatesPlan := core.GetBoolOrDefault(data.TrustCertificates, false)
+	trustFingerprintsPlan := core.GetBoolOrDefault(data.TrustFingerprints, false)
+
+	svc := r.GetClient().NewConnectionCreate().
+		Paused(true).
+		Service(data.Service.ValueString()).
+		GroupID(data.GroupId.ValueString()).
+		RunSetupTests(runSetupTestsPlan).
+		TrustCertificates(trustCertificatesPlan).
+		TrustFingerprints(trustFingerprintsPlan)
+
+	if configMap != nil {
+		svc.ConfigCustom(&configMap)
+	}
+	if authMap != nil {
+		svc.AuthCustom(&authMap)
+	}
+
+	r.applyCreateRootFields(svc, data)
+
+	response, err := svc.DoCustom(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create Connection V2 Resource.",
+			fmt.Sprintf("%v; code: %v; message: %v", err, response.Code, response.Message),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(data.ReadFromCreateResponse(ctx, response, meta, configMap)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.Auth = preserveDynamic(data.Auth)
+	data.RunSetupTests = types.BoolValue(runSetupTestsPlan)
+	data.TrustCertificates = types.BoolValue(trustCertificatesPlan)
+	data.TrustFingerprints = types.BoolValue(trustFingerprintsPlan)
+
+	r.warnFailedSetupTests(response.Data.SetupTests, &resp.Diagnostics)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *connectionV2) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	resp.Diagnostics.AddError(
-		"fivetran_connection_v2 is not registered",
-		"The resource skeleton is present for development, but CRUD is implemented in a follow-up change and the resource is not registered with the provider yet.",
-	)
+	if r.GetClient() == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Fivetran Client",
+			"Please report this issue to the provider developers.",
+		)
+		return
+	}
+
+	var data model.ConnectionV2ResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := r.GetClient().NewConnectionDetails().ConnectionID(data.Id.ValueString()).DoCustom(ctx)
+	if err != nil {
+		if response.Code == "NotFound_Connector" || response.Code == "NotFound_Connection" {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Unable to Read Connection V2 Resource.",
+			fmt.Sprintf("%v; code: %v; message: %v", err, response.Code, response.Message),
+		)
+		return
+	}
+
+	meta, err := r.connectorMetadata(ctx, response.Data.Service)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Fetch Connection Metadata.",
+			fmt.Sprintf("Unable to fetch metadata for service %q: %v", response.Data.Service, err),
+		)
+		return
+	}
+
+	configMask, diags := core.DynamicToMap(ctx, data.Config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	auth := data.Auth
+
+	resp.Diagnostics.Append(data.ReadFromResponse(ctx, response, meta, configMask)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.Auth = preserveDynamic(auth)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *connectionV2) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	resp.Diagnostics.AddError(
-		"fivetran_connection_v2 is not registered",
-		"The resource skeleton is present for development, but CRUD is implemented in a follow-up change and the resource is not registered with the provider yet.",
-	)
+	if r.GetClient() == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Fivetran Client",
+			"Please report this issue to the provider developers.",
+		)
+		return
+	}
+
+	var plan, state model.ConnectionV2ResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	meta, err := r.connectorMetadata(ctx, plan.Service.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Fetch Connection Metadata.",
+			fmt.Sprintf("Unable to fetch metadata for service %q: %v", plan.Service.ValueString(), err),
+		)
+		return
+	}
+
+	planConfig, planAuth := r.dynamicPlanMaps(ctx, plan, &resp.Diagnostics)
+	stateConfig, stateAuth := r.dynamicStateMaps(ctx, state, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	configPatch := core.PrepareConfigPatchDynamic(planConfig, stateConfig, &meta.Config)
+	authPatch := core.PrepareConfigPatchDynamic(planAuth, stateAuth, &meta.Auth)
+
+	runSetupTestsPlan := core.GetBoolOrDefault(plan.RunSetupTests, false)
+	trustCertificatesPlan := core.GetBoolOrDefault(plan.TrustCertificates, false)
+	trustFingerprintsPlan := core.GetBoolOrDefault(plan.TrustFingerprints, false)
+
+	svc := r.GetClient().NewConnectionUpdate().
+		ConnectionID(state.Id.ValueString()).
+		RunSetupTests(runSetupTestsPlan).
+		TrustCertificates(trustCertificatesPlan).
+		TrustFingerprints(trustFingerprintsPlan)
+
+	if len(configPatch) > 0 {
+		svc.ConfigCustom(&configPatch)
+	}
+	if len(authPatch) > 0 {
+		svc.AuthCustom(&authPatch)
+	}
+
+	r.applyUpdateRootFields(svc, plan, state)
+
+	response, err := svc.DoCustom(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Update Connection V2 Resource.",
+			fmt.Sprintf("%v; code: %v; message: %v", err, response.Code, response.Message),
+		)
+		return
+	}
+
+	r.warnFailedSetupTests(response.Data.SetupTests, &resp.Diagnostics)
+
+	details, err := r.GetClient().NewConnectionDetails().ConnectionID(state.Id.ValueString()).DoCustom(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Connection V2 Resource After Update.",
+			fmt.Sprintf("%v; code: %v; message: %v", err, details.Code, details.Message),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(plan.ReadFromResponse(ctx, details, meta, planConfig)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.Auth = preserveDynamic(plan.Auth)
+	plan.RunSetupTests = types.BoolValue(runSetupTestsPlan)
+	plan.TrustCertificates = types.BoolValue(trustCertificatesPlan)
+	plan.TrustFingerprints = types.BoolValue(trustFingerprintsPlan)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *connectionV2) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	resp.Diagnostics.AddError(
-		"fivetran_connection_v2 is not registered",
-		"The resource skeleton is present for development, but CRUD is implemented in a follow-up change and the resource is not registered with the provider yet.",
-	)
+	if r.GetClient() == nil {
+		resp.Diagnostics.AddError(
+			"Unconfigured Fivetran Client",
+			"Please report this issue to the provider developers.",
+		)
+		return
+	}
+
+	var data model.ConnectionV2ResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteResponse, err := r.GetClient().NewConnectionDelete().ConnectionID(data.Id.ValueString()).Do(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Connection V2 Resource.",
+			fmt.Sprintf("%v; code: %v; message: %v", err, deleteResponse.Code, deleteResponse.Message),
+		)
+		return
+	}
+}
+
+func (r *connectionV2) connectorMetadata(ctx context.Context, service string) (*metadata.ConnectorMetadata, error) {
+	cache := r.GetMetadataCache()
+	if cache == nil {
+		cache = &sync.Map{}
+	}
+	return core.GetCachedConnectorMetadata(ctx, r.GetClient(), cache, service)
+}
+
+func (r *connectionV2) dynamicPlanMaps(ctx context.Context, data model.ConnectionV2ResourceModel, diags *diag.Diagnostics) (map[string]interface{}, map[string]interface{}) {
+	configMap, configDiags := core.DynamicToMap(ctx, data.Config)
+	diags.Append(configDiags...)
+
+	authMap, authDiags := core.DynamicToMap(ctx, data.Auth)
+	diags.Append(authDiags...)
+
+	return configMap, authMap
+}
+
+func (r *connectionV2) dynamicStateMaps(ctx context.Context, data model.ConnectionV2ResourceModel, diags *diag.Diagnostics) (map[string]interface{}, map[string]interface{}) {
+	return r.dynamicPlanMaps(ctx, data, diags)
+}
+
+func (r *connectionV2) applyCreateRootFields(svc *connections.ConnectionCreateService, data model.ConnectionV2ResourceModel) {
+	if !data.SyncFrequency.IsNull() && !data.SyncFrequency.IsUnknown() {
+		value := int(data.SyncFrequency.ValueInt64())
+		svc.SyncFrequency(&value)
+	}
+	if !data.DailySyncTime.IsNull() && !data.DailySyncTime.IsUnknown() {
+		svc.DailySyncTime(data.DailySyncTime.ValueString())
+	}
+	if !data.PauseAfterTrial.IsNull() && !data.PauseAfterTrial.IsUnknown() {
+		svc.PauseAfterTrial(data.PauseAfterTrial.ValueBool())
+	}
+	if !data.ProxyAgentId.IsNull() && !data.ProxyAgentId.IsUnknown() {
+		svc.ProxyAgentId(data.ProxyAgentId.ValueString())
+	}
+	if !data.NetworkingMethod.IsNull() && !data.NetworkingMethod.IsUnknown() {
+		svc.NetworkingMethod(data.NetworkingMethod.ValueString())
+	}
+	if !data.PrivateLinkId.IsNull() && !data.PrivateLinkId.IsUnknown() {
+		svc.PrivateLinkId(data.PrivateLinkId.ValueString())
+	}
+	if !data.HybridDeploymentAgentId.IsNull() && !data.HybridDeploymentAgentId.IsUnknown() {
+		svc.HybridDeploymentAgentId(data.HybridDeploymentAgentId.ValueString())
+	}
+	if !data.DataDelaySensitivity.IsNull() && !data.DataDelaySensitivity.IsUnknown() {
+		svc.DataDelaySensitivity(data.DataDelaySensitivity.ValueString())
+	}
+	if !data.DataDelayThreshold.IsNull() && !data.DataDelayThreshold.IsUnknown() {
+		value := int(data.DataDelayThreshold.ValueInt64())
+		svc.DataDelayThreshold(&value)
+	}
+}
+
+func (r *connectionV2) applyUpdateRootFields(svc *connections.ConnectionUpdateService, plan, state model.ConnectionV2ResourceModel) {
+	if !plan.SyncFrequency.Equal(state.SyncFrequency) && !plan.SyncFrequency.IsNull() && !plan.SyncFrequency.IsUnknown() {
+		value := int(plan.SyncFrequency.ValueInt64())
+		svc.SyncFrequency(&value)
+	}
+	if !plan.ScheduleType.Equal(state.ScheduleType) && !plan.ScheduleType.IsNull() && !plan.ScheduleType.IsUnknown() {
+		svc.ScheduleType(plan.ScheduleType.ValueString())
+	}
+	if !plan.DailySyncTime.Equal(state.DailySyncTime) && !plan.DailySyncTime.IsNull() && !plan.DailySyncTime.IsUnknown() {
+		svc.DailySyncTime(plan.DailySyncTime.ValueString())
+	}
+	if !plan.PauseAfterTrial.Equal(state.PauseAfterTrial) && !plan.PauseAfterTrial.IsNull() && !plan.PauseAfterTrial.IsUnknown() {
+		svc.PauseAfterTrial(plan.PauseAfterTrial.ValueBool())
+	}
+	if !plan.ProxyAgentId.Equal(state.ProxyAgentId) && !plan.ProxyAgentId.IsNull() && !plan.ProxyAgentId.IsUnknown() {
+		svc.ProxyAgentId(plan.ProxyAgentId.ValueString())
+	}
+	if !plan.NetworkingMethod.Equal(state.NetworkingMethod) && !plan.NetworkingMethod.IsNull() && !plan.NetworkingMethod.IsUnknown() {
+		svc.NetworkingMethod(plan.NetworkingMethod.ValueString())
+	}
+	if !plan.PrivateLinkId.Equal(state.PrivateLinkId) && !plan.PrivateLinkId.IsNull() && !plan.PrivateLinkId.IsUnknown() {
+		svc.PrivateLinkId(plan.PrivateLinkId.ValueString())
+	}
+	if !plan.HybridDeploymentAgentId.Equal(state.HybridDeploymentAgentId) && !plan.HybridDeploymentAgentId.IsNull() && !plan.HybridDeploymentAgentId.IsUnknown() {
+		svc.HybridDeploymentAgentId(plan.HybridDeploymentAgentId.ValueString())
+	}
+	if !plan.DataDelaySensitivity.Equal(state.DataDelaySensitivity) && !plan.DataDelaySensitivity.IsNull() && !plan.DataDelaySensitivity.IsUnknown() {
+		svc.DataDelaySensitivity(plan.DataDelaySensitivity.ValueString())
+	}
+	if !plan.DataDelayThreshold.Equal(state.DataDelayThreshold) && !plan.DataDelayThreshold.IsNull() && !plan.DataDelayThreshold.IsUnknown() {
+		value := int(plan.DataDelayThreshold.ValueInt64())
+		svc.DataDelayThreshold(&value)
+	}
+}
+
+func (r *connectionV2) warnFailedSetupTests(setupTests []common.SetupTestResponse, diags *diag.Diagnostics) {
+	for _, tr := range setupTests {
+		if tr.Status != "PASSED" && tr.Status != "SKIPPED" {
+			diags.AddWarning(
+				fmt.Sprintf("Connection setup test `%v` has status `%v`", tr.Title, tr.Status),
+				tr.Message,
+			)
+		}
+	}
+}
+
+func preserveDynamic(value types.Dynamic) types.Dynamic {
+	if value.IsUnknown() {
+		return types.DynamicNull()
+	}
+	return value
 }

--- a/fivetran/framework/resources/connection_v2.go
+++ b/fivetran/framework/resources/connection_v2.go
@@ -1,0 +1,55 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core"
+	fivetranSchema "github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func ConnectionV2() resource.Resource {
+	return &connectionV2{}
+}
+
+type connectionV2 struct {
+	core.ProviderResource
+}
+
+var _ resource.ResourceWithConfigure = &connectionV2{}
+
+func (r *connectionV2) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_connection_v2"
+}
+
+func (r *connectionV2) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = fivetranSchema.ConnectionV2ResourceSchema()
+}
+
+func (r *connectionV2) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.AddError(
+		"fivetran_connection_v2 is not registered",
+		"The resource skeleton is present for development, but CRUD is implemented in a follow-up change and the resource is not registered with the provider yet.",
+	)
+}
+
+func (r *connectionV2) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	resp.Diagnostics.AddError(
+		"fivetran_connection_v2 is not registered",
+		"The resource skeleton is present for development, but CRUD is implemented in a follow-up change and the resource is not registered with the provider yet.",
+	)
+}
+
+func (r *connectionV2) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError(
+		"fivetran_connection_v2 is not registered",
+		"The resource skeleton is present for development, but CRUD is implemented in a follow-up change and the resource is not registered with the provider yet.",
+	)
+}
+
+func (r *connectionV2) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.Diagnostics.AddError(
+		"fivetran_connection_v2 is not registered",
+		"The resource skeleton is present for development, but CRUD is implemented in a follow-up change and the resource is not registered with the provider yet.",
+	)
+}

--- a/fivetran/framework/resources/connection_v2_test.go
+++ b/fivetran/framework/resources/connection_v2_test.go
@@ -1,0 +1,140 @@
+package resources_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework"
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/resources"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+func TestConnectionV2SchemaShape(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	r := resources.ConnectionV2()
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", schemaResp.Diagnostics)
+	}
+
+	attrs := schemaResp.Schema.Attributes
+	if schemaResp.Schema.Version != 0 {
+		t.Fatalf("unexpected schema version: got %d, want 0", schemaResp.Schema.Version)
+	}
+	if _, ok := attrs["destination_schema"]; ok {
+		t.Fatal("fivetran_connection_v2 must not expose destination_schema as a root attribute")
+	}
+	if _, ok := attrs["local_processing_agent_id"]; ok {
+		t.Fatal("fivetran_connection_v2 must not expose deprecated local_processing_agent_id")
+	}
+
+	assertStringAttribute(t, attrs, "service", true, false, false)
+	assertStringAttribute(t, attrs, "group_id", true, false, false)
+	assertDynamicAttribute(t, attrs, "config", true, true, false)
+	assertDynamicAttribute(t, attrs, "auth", true, true, true)
+	assertBoolAttribute(t, attrs, "paused", false, true, true)
+	assertInt64Attribute(t, attrs, "sync_frequency", false, true, true)
+	assertBoolAttribute(t, attrs, "run_setup_tests", false, true, false)
+	assertBoolAttribute(t, attrs, "trust_certificates", false, true, false)
+	assertBoolAttribute(t, attrs, "trust_fingerprints", false, true, false)
+
+	status, ok := attrs["status"].(resourceSchema.SingleNestedAttribute)
+	if !ok {
+		t.Fatalf("status has type %T, want SingleNestedAttribute", attrs["status"])
+	}
+	if !status.Computed {
+		t.Fatal("status should be computed")
+	}
+	if _, ok := status.Attributes["tasks"].(resourceSchema.SetNestedAttribute); !ok {
+		t.Fatalf("status.tasks has type %T, want SetNestedAttribute", status.Attributes["tasks"])
+	}
+	if _, ok := status.Attributes["warnings"].(resourceSchema.SetNestedAttribute); !ok {
+		t.Fatalf("status.warnings has type %T, want SetNestedAttribute", status.Attributes["warnings"])
+	}
+}
+
+func TestConnectionV2NotRegistered(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	p := framework.FivetranProvider()
+	for _, resourceFactory := range p.Resources(ctx) {
+		r := resourceFactory()
+		var metadataResp resource.MetadataResponse
+		r.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "fivetran"}, &metadataResp)
+		if metadataResp.TypeName == "fivetran_connection_v2" {
+			t.Fatal("fivetran_connection_v2 must remain unregistered until the registration ticket")
+		}
+	}
+
+	var metadataResp provider.MetadataResponse
+	p.Metadata(ctx, provider.MetadataRequest{}, &metadataResp)
+	if metadataResp.TypeName != "fivetran" {
+		t.Fatalf("unexpected provider type name: got %q", metadataResp.TypeName)
+	}
+}
+
+func assertStringAttribute(t *testing.T, attrs map[string]resourceSchema.Attribute, name string, required, optional, computed bool) {
+	t.Helper()
+
+	attr, ok := attrs[name].(resourceSchema.StringAttribute)
+	if !ok {
+		t.Fatalf("%s has type %T, want StringAttribute", name, attrs[name])
+	}
+	assertAttributeMode(t, name, attr.Required, attr.Optional, attr.Computed, required, optional, computed)
+}
+
+func assertBoolAttribute(t *testing.T, attrs map[string]resourceSchema.Attribute, name string, required, optional, computed bool) {
+	t.Helper()
+
+	attr, ok := attrs[name].(resourceSchema.BoolAttribute)
+	if !ok {
+		t.Fatalf("%s has type %T, want BoolAttribute", name, attrs[name])
+	}
+	assertAttributeMode(t, name, attr.Required, attr.Optional, attr.Computed, required, optional, computed)
+}
+
+func assertInt64Attribute(t *testing.T, attrs map[string]resourceSchema.Attribute, name string, required, optional, computed bool) {
+	t.Helper()
+
+	attr, ok := attrs[name].(resourceSchema.Int64Attribute)
+	if !ok {
+		t.Fatalf("%s has type %T, want Int64Attribute", name, attrs[name])
+	}
+	assertAttributeMode(t, name, attr.Required, attr.Optional, attr.Computed, required, optional, computed)
+}
+
+func assertDynamicAttribute(t *testing.T, attrs map[string]resourceSchema.Attribute, name string, optional, computed, sensitive bool) {
+	t.Helper()
+
+	attr, ok := attrs[name].(resourceSchema.DynamicAttribute)
+	if !ok {
+		t.Fatalf("%s has type %T, want DynamicAttribute", name, attrs[name])
+	}
+	assertAttributeMode(t, name, attr.Required, attr.Optional, attr.Computed, false, optional, computed)
+	if attr.Sensitive != sensitive {
+		t.Fatalf("%s sensitive = %v, want %v", name, attr.Sensitive, sensitive)
+	}
+}
+
+func assertAttributeMode(t *testing.T, name string, gotRequired, gotOptional, gotComputed, wantRequired, wantOptional, wantComputed bool) {
+	t.Helper()
+
+	if gotRequired != wantRequired || gotOptional != wantOptional || gotComputed != wantComputed {
+		t.Fatalf(
+			"%s mode = required:%v optional:%v computed:%v, want required:%v optional:%v computed:%v",
+			name,
+			gotRequired,
+			gotOptional,
+			gotComputed,
+			wantRequired,
+			wantOptional,
+			wantComputed,
+		)
+	}
+}

--- a/fivetran/framework/resources/connection_v2_test.go
+++ b/fivetran/framework/resources/connection_v2_test.go
@@ -39,7 +39,7 @@ func TestConnectionV2SchemaShape(t *testing.T) {
 	assertStringAttribute(t, attrs, "service", true, false, false)
 	assertStringAttribute(t, attrs, "group_id", true, false, false)
 	assertDynamicAttribute(t, attrs, "config", true, true, false)
-	assertDynamicAttribute(t, attrs, "auth", true, true, true)
+	assertDynamicAttribute(t, attrs, "auth", true, false, true)
 	assertInt64Attribute(t, attrs, "sync_frequency", false, true, true)
 	assertBoolAttribute(t, attrs, "run_setup_tests", false, true, false)
 	assertBoolAttribute(t, attrs, "trust_certificates", false, true, false)

--- a/fivetran/framework/resources/connection_v2_test.go
+++ b/fivetran/framework/resources/connection_v2_test.go
@@ -32,12 +32,14 @@ func TestConnectionV2SchemaShape(t *testing.T) {
 	if _, ok := attrs["local_processing_agent_id"]; ok {
 		t.Fatal("fivetran_connection_v2 must not expose deprecated local_processing_agent_id")
 	}
+	if _, ok := attrs["paused"]; ok {
+		t.Fatal("fivetran_connection_v2 must not expose paused; pause state is managed by fivetran_connection_v2_pause_state")
+	}
 
 	assertStringAttribute(t, attrs, "service", true, false, false)
 	assertStringAttribute(t, attrs, "group_id", true, false, false)
 	assertDynamicAttribute(t, attrs, "config", true, true, false)
 	assertDynamicAttribute(t, attrs, "auth", true, true, true)
-	assertBoolAttribute(t, attrs, "paused", false, true, true)
 	assertInt64Attribute(t, attrs, "sync_frequency", false, true, true)
 	assertBoolAttribute(t, attrs, "run_setup_tests", false, true, false)
 	assertBoolAttribute(t, attrs, "trust_certificates", false, true, false)


### PR DESCRIPTION
## Summary

Adds the initial metadata-driven connection resource foundation.

This PR includes:

- connection resource skeleton
- static root schema/model for connection-owned fields
- dynamic `config` and `auth` attributes backed by connector metadata
- CRUD implementation using the existing `/connections` API
- import support for existing connections
- metadata cache access from provider resources
- dynamic config projection and PATCH helpers moved into `framework/core`

`paused` is intentionally not part of this resource. Connections are still created paused internally, and pause/unpause will be handled by the separate pause-state resource.

## Notes

- The resource is not registered in `provider.go` yet.
- Plan-time validation, `ModifyPlan`, historical resync warnings, and final registration are handled separately.
- Destination schema fields are represented inside `config`, matching the API shape.

## Validation

go test ./fivetran/framework/...