### PR TITLE
`fivetran_connection_config`: do not fail when plan-only attributes are changed, but state attributes are not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.34...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.35...HEAD)
+
+## [v1.9.35](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.35...v1.9.34)
+
+### Fixed
+- `fivetran_connection_config`: do not fail when plan-only attributes are changed.
 
 ### Added
 - Internal: connector metadata field status helpers for future validation improvements.

--- a/fivetran/framework/provider.go
+++ b/fivetran/framework/provider.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const Version = "1.9.32" // Current provider version
+const Version = "1.9.35" // Current provider version
 
 type fivetranProvider struct {
 	mockClient    httputils.HttpClient

--- a/fivetran/framework/resources/connection_config.go
+++ b/fivetran/framework/resources/connection_config.go
@@ -150,6 +150,8 @@ func (r *connectionConfig) Update(ctx context.Context, req resource.UpdateReques
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
 	if plan.Config.Equal(state.Config) && plan.Auth.Equal(state.Auth) {
+
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 		return
 	}
 

--- a/fivetran/tests/e2e/resource_connection_config_e2e_test.go
+++ b/fivetran/tests/e2e/resource_connection_config_e2e_test.go
@@ -161,12 +161,107 @@ func TestResourceConnectionConfigOnlyConfigE2E(t *testing.T) {
 						port = 5432
 						database = "config_only_db"
 					})
+
+					run_setup_tests = false
 				}
 		  `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testFivetranConnectionConfigResourceCreate(t, "fivetran_connection_config.test_config"),
 					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "connection_id"),
 					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "config"),
+					resource.TestCheckResourceAttr("fivetran_connection_config.test_config", "run_setup_tests", "false"),
+				),
+			},
+
+			{
+				Config: `
+				resource "fivetran_group" "test_group" {
+					provider = fivetran-provider
+					name = "test_group_config_only"
+			    }
+
+			    resource "fivetran_connection" "test_connection" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "postgres"
+
+					destination_schema {
+						prefix = "postgres_config_only"
+					}
+
+					config = jsonencode({
+						update_method = "QUERY_BASED"
+					})
+
+					run_setup_tests = false
+				}
+
+				resource "fivetran_connection_config" "test_config" {
+					provider = fivetran-provider
+					connection_id = fivetran_connection.test_connection.id
+
+					config = jsonencode({
+						update_method = "QUERY_BASED"
+						user = "config_only_user"
+						host = "config.example.com"
+						port = 5432
+						database = "config_only_db"
+					})
+
+					run_setup_tests = true
+				}
+		  `,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testFivetranConnectionConfigResourceCreate(t, "fivetran_connection_config.test_config"),
+					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "connection_id"),
+					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "config"),
+					resource.TestCheckResourceAttr("fivetran_connection_config.test_config", "run_setup_tests", "true"),
+				),
+			},
+
+			{
+				Config: `
+				resource "fivetran_group" "test_group" {
+					provider = fivetran-provider
+					name = "test_group_config_only"
+			    }
+
+			    resource "fivetran_connection" "test_connection" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "postgres"
+
+					destination_schema {
+						prefix = "postgres_config_only"
+					}
+
+					config = jsonencode({
+						update_method = "QUERY_BASED"
+					})
+
+					run_setup_tests = false
+				}
+
+				resource "fivetran_connection_config" "test_config" {
+					provider = fivetran-provider
+					connection_id = fivetran_connection.test_connection.id
+
+					config = jsonencode({
+						update_method = "QUERY_BASED"
+						user = "config_only_user"
+						host = "config.example.com"
+						port = 5432
+						database = "config_only_db"
+					})
+
+					run_setup_tests = false
+				}
+		  `,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testFivetranConnectionConfigResourceCreate(t, "fivetran_connection_config.test_config"),
+					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "connection_id"),
+					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "config"),
+					resource.TestCheckResourceAttr("fivetran_connection_config.test_config", "run_setup_tests", "false"),
 				),
 			},
 		},
@@ -216,6 +311,53 @@ func TestResourceConnectionConfigOnlyAuthE2E(t *testing.T) {
 				}
 		  `,
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("fivetran_connection.test_connection", "run_setup_tests", "false"),
+
+					testFivetranConnectionConfigResourceCreate(t, "fivetran_connection_config.test_config"),
+					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "connection_id"),
+					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "auth"),
+				),
+			},
+
+			{
+				Config: `
+				resource "fivetran_group" "test_group" {
+					provider = fivetran-provider
+					name = "test_group_auth_only"
+			    }
+
+			    resource "fivetran_connection" "test_connection" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "postgres"
+
+					destination_schema {
+						prefix = "postgres_auth_only"
+					}
+
+					config = jsonencode({
+						update_method = "QUERY_BASED"
+					})
+
+					run_setup_tests = true
+				}
+
+				resource "fivetran_connection_config" "test_config" {
+					provider = fivetran-provider
+					connection_id = fivetran_connection.test_connection.id
+
+					config = jsonencode({
+						update_method = "QUERY_BASED"
+					})
+
+					auth = jsonencode({
+						password = "auth_only_password"
+					})
+				}
+		  `,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("fivetran_connection.test_connection", "run_setup_tests", "true"),
+
 					testFivetranConnectionConfigResourceCreate(t, "fivetran_connection_config.test_config"),
 					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "connection_id"),
 					resource.TestCheckResourceAttrSet("fivetran_connection_config.test_config", "auth"),

--- a/fivetran/tests/e2e/resource_connector_e2e_test.go
+++ b/fivetran/tests/e2e/resource_connector_e2e_test.go
@@ -686,14 +686,11 @@ func TestWorkdayAdaptiveReportsE2E(t *testing.T) {
 							version_sync_strategy = "SYNC_SELECT_VERSIONS"
 							include_zero_rows = true
 							versions = ["2945"]
-							accounts  { 
-							  id = "3"
-							  flag = true 
-							}
-							accounts { 
-							  id = "4"
-							  flag = true 
-							}
+							account_sync_mode = "SELECT_SPECIFIC_ACCOUNTS"
+							selected_accounts = [ 
+							  "3,true",
+							  "4,true"
+							]
 							dimensions = ["3","4"]
 						}
 					}
@@ -711,7 +708,8 @@ func TestWorkdayAdaptiveReportsE2E(t *testing.T) {
 					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.include_zero_rows", "true"),
 					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.versions.#", "1"),
 					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.versions.0", "2945"),
-					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.accounts.#", "2"),
+					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.account_sync_mode", "SELECT_SPECIFIC_ACCOUNTS"),
+					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.selected_accounts.#", "2"),
 					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.dimensions.#", "2"),
 					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.dimensions.0", "3"),
 					resource.TestCheckResourceAttr("fivetran_connector.workday_adaptive_connection", "config.reports.0.dimensions.1", "4"),


### PR DESCRIPTION
A fix for `fivetran_connection_config` when plan-only attributes changed but state attributes were not changed. Previously may produce error as:

```
Provider produced inconsistent result after apply
...
run_setup_tests: was cty.True, but now cty.False
```