### PR TITLE
Add connection v2 plan-time validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.35...HEAD)
 
 ### Added
-- Internal: metadata-driven plan-time validation for dynamic connection config/auth fields.
+- `fivetran_connection_v2`: metadata-driven plan-time validation for dynamic `config` / `auth` fields (override via provider `skip_plan_time_validation`).
 
 ## [v1.9.35](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.35...v1.9.34)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.35...HEAD)
 
+### Added
+- Internal: metadata-driven plan-time validation for dynamic connection config/auth fields.
+
 ## [v1.9.35](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.35...v1.9.34)
 
 ### Fixed

--- a/fivetran/framework/core/config_projection.go
+++ b/fivetran/framework/core/config_projection.go
@@ -29,7 +29,7 @@ func DynamicToMap(ctx context.Context, dyn types.Dynamic) (map[string]interface{
 	}
 	m, ok := result.(map[string]interface{})
 	if !ok {
-		diags.AddError("Dynamic config is not an object", "Expected an object value for dynamic config.")
+		diags.AddError("Dynamic value is not an object", "Expected an object value for this dynamic attribute.")
 		return nil, diags
 	}
 	return m, diags
@@ -59,7 +59,7 @@ func DynamicToMapPreserveUnknown(ctx context.Context, dyn types.Dynamic) (map[st
 	}
 	m, ok := result.(map[string]interface{})
 	if !ok {
-		diags.AddError("Dynamic config is not an object", "Expected an object value for dynamic config.")
+		diags.AddError("Dynamic value is not an object", "Expected an object value for this dynamic attribute.")
 		return nil, diags
 	}
 	return m, diags

--- a/fivetran/framework/core/config_projection.go
+++ b/fivetran/framework/core/config_projection.go
@@ -35,6 +35,36 @@ func DynamicToMap(ctx context.Context, dyn types.Dynamic) (map[string]interface{
 	return m, diags
 }
 
+type DynamicUnknownValue struct{}
+
+func IsDynamicUnknownValue(value interface{}) bool {
+	_, ok := value.(DynamicUnknownValue)
+	return ok
+}
+
+// DynamicToMapPreserveUnknown converts dynamic objects like DynamicToMap, but preserves
+// nested unknown values so plan-time validation can distinguish them from explicit nulls.
+func DynamicToMapPreserveUnknown(ctx context.Context, dyn types.Dynamic) (map[string]interface{}, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if dyn.IsNull() || dyn.IsUnknown() {
+		return nil, diags
+	}
+	underlying := dyn.UnderlyingValue()
+	if underlying == nil || underlying.IsNull() || underlying.IsUnknown() {
+		return nil, diags
+	}
+	result := attrToInterfacePreserveUnknown(ctx, underlying)
+	if result == nil {
+		return nil, diags
+	}
+	m, ok := result.(map[string]interface{})
+	if !ok {
+		diags.AddError("Dynamic config is not an object", "Expected an object value for dynamic config.")
+		return nil, diags
+	}
+	return m, diags
+}
+
 func attrToInterface(ctx context.Context, val attr.Value) interface{} {
 	if val == nil || val.IsNull() || val.IsUnknown() {
 		return nil
@@ -74,6 +104,48 @@ func attrToInterface(ctx context.Context, val attr.Value) interface{} {
 	return nil
 }
 
+func attrToInterfacePreserveUnknown(ctx context.Context, val attr.Value) interface{} {
+	if val == nil || val.IsNull() {
+		return nil
+	}
+	if val.IsUnknown() {
+		return DynamicUnknownValue{}
+	}
+	switch v := val.(type) {
+	case types.String:
+		return v.ValueString()
+	case types.Bool:
+		return v.ValueBool()
+	case types.Int64:
+		return v.ValueInt64()
+	case types.Float64:
+		return v.ValueFloat64()
+	case types.Number:
+		n := v.ValueBigFloat()
+		if n == nil {
+			return nil
+		}
+		if i, acc := n.Int64(); acc == big.Exact {
+			return i
+		}
+		f, _ := n.Float64()
+		return f
+	case types.Dynamic:
+		return attrToInterfacePreserveUnknown(ctx, v.UnderlyingValue())
+	case types.Object:
+		return convertObjectAttrsPreserveUnknown(ctx, v.Attributes())
+	case types.Map:
+		return convertObjectAttrsPreserveUnknown(ctx, v.Elements())
+	case types.List:
+		return convertSliceElemsPreserveUnknown(ctx, v.Elements())
+	case types.Set:
+		return convertSliceElemsPreserveUnknown(ctx, v.Elements())
+	case types.Tuple:
+		return convertSliceElemsPreserveUnknown(ctx, v.Elements())
+	}
+	return nil
+}
+
 func convertObjectAttrs(ctx context.Context, elems map[string]attr.Value) map[string]interface{} {
 	result := make(map[string]interface{}, len(elems))
 	for k, v := range elems {
@@ -82,10 +154,26 @@ func convertObjectAttrs(ctx context.Context, elems map[string]attr.Value) map[st
 	return result
 }
 
+func convertObjectAttrsPreserveUnknown(ctx context.Context, elems map[string]attr.Value) map[string]interface{} {
+	result := make(map[string]interface{}, len(elems))
+	for k, v := range elems {
+		result[k] = attrToInterfacePreserveUnknown(ctx, v)
+	}
+	return result
+}
+
 func convertSliceElems(ctx context.Context, elems []attr.Value) []interface{} {
 	result := make([]interface{}, len(elems))
 	for i, v := range elems {
 		result[i] = attrToInterface(ctx, v)
+	}
+	return result
+}
+
+func convertSliceElemsPreserveUnknown(ctx context.Context, elems []attr.Value) []interface{} {
+	result := make([]interface{}, len(elems))
+	for i, v := range elems {
+		result[i] = attrToInterfacePreserveUnknown(ctx, v)
 	}
 	return result
 }

--- a/fivetran/framework/core/config_projection.go
+++ b/fivetran/framework/core/config_projection.go
@@ -197,7 +197,7 @@ func project(remote, mask map[string]interface{}, slot *metadata.Property) map[s
 	result := make(map[string]interface{}, len(mask))
 
 	for key, maskVal := range mask {
-		prop := slotProp(slot, key)
+		prop := SlotProp(slot, key)
 
 		if prop != nil && prop.Format == "password" {
 			result[key] = maskVal
@@ -233,7 +233,7 @@ func project(remote, mask map[string]interface{}, slot *metadata.Property) map[s
 		if _, inMask := mask[key]; inMask {
 			continue
 		}
-		prop := slotProp(slot, key)
+		prop := SlotProp(slot, key)
 		if prop != nil && prop.Readonly {
 			result[key] = remoteVal
 		}
@@ -256,7 +256,7 @@ func PrepareConfigPatchDynamic(plan, state map[string]interface{}, slot *metadat
 	patch := make(map[string]interface{})
 
 	for k, planVal := range plan {
-		prop := slotProp(slot, k)
+		prop := SlotProp(slot, k)
 		if prop != nil && (prop.Readonly || prop.Immutable) {
 			continue
 		}
@@ -270,7 +270,7 @@ func PrepareConfigPatchDynamic(plan, state map[string]interface{}, slot *metadat
 		if _, inPlan := plan[k]; inPlan {
 			continue
 		}
-		prop := slotProp(slot, k)
+		prop := SlotProp(slot, k)
 		if prop != nil && (prop.Readonly || prop.Immutable) {
 			continue
 		}
@@ -282,7 +282,9 @@ func PrepareConfigPatchDynamic(plan, state map[string]interface{}, slot *metadat
 	return patch
 }
 
-func slotProp(slot *metadata.Property, key string) *metadata.Property {
+// SlotProp returns the child Property for key within a slot's Properties map,
+// or nil if the slot, its Properties map, or the key is absent.
+func SlotProp(slot *metadata.Property, key string) *metadata.Property {
 	if slot == nil || slot.Properties == nil {
 		return nil
 	}

--- a/fivetran/framework/core/config_projection_test.go
+++ b/fivetran/framework/core/config_projection_test.go
@@ -68,6 +68,25 @@ func TestDynamicToMap_NestedObject(t *testing.T) {
 	}
 }
 
+func TestDynamicToMapPreserveUnknown_NestedValue(t *testing.T) {
+	t.Parallel()
+	obj, diags := types.ObjectValue(
+		map[string]attr.Type{"bucket": types.StringType},
+		map[string]attr.Value{"bucket": types.StringUnknown()},
+	)
+	if diags.HasError() {
+		t.Fatalf("object diagnostics: %v", diags)
+	}
+
+	m, mapDiags := DynamicToMapPreserveUnknown(context.Background(), types.DynamicValue(obj))
+	if mapDiags.HasError() {
+		t.Fatalf("unexpected error: %v", mapDiags)
+	}
+	if !IsDynamicUnknownValue(m["bucket"]) {
+		t.Fatalf("bucket should preserve unknown sentinel, got %T %[1]v", m["bucket"])
+	}
+}
+
 func TestDynamicToMap_EmptyStringPreserved(t *testing.T) {
 	t.Parallel()
 	obj, _ := types.ObjectValue(

--- a/fivetran/framework/core/core.go
+++ b/fivetran/framework/core/core.go
@@ -24,8 +24,9 @@ import (
 )
 
 type clientContainer struct {
-	client        *fivetran.Client
-	metadataCache *sync.Map
+	client                 *fivetran.Client
+	metadataCache          *sync.Map
+	skipPlanTimeValidation bool
 }
 
 type ProviderDatasource struct {
@@ -46,6 +47,10 @@ func (d *clientContainer) GetClient() *fivetran.Client {
 
 func (d *clientContainer) GetMetadataCache() *sync.Map {
 	return d.metadataCache
+}
+
+func (d *clientContainer) GetSkipPlanTimeValidation() bool {
+	return d.skipPlanTimeValidation
 }
 
 func (d *ProviderAction) Configure(ctx context.Context, req action.ConfigureRequest, resp *action.ConfigureResponse) {
@@ -71,6 +76,7 @@ func (d *clientContainer) getClient(diag diag.Diagnostics, data any) {
 	case *ProviderResourceData:
 		d.client = v.Client
 		d.metadataCache = v.MetadataCache
+		d.skipPlanTimeValidation = v.SkipPlanTimeValidation
 	default:
 		diag.AddError(
 			"Unexpected Resource Configure Type",

--- a/fivetran/framework/core/metadata_cache.go
+++ b/fivetran/framework/core/metadata_cache.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	fivetran "github.com/fivetran/go-fivetran"
@@ -12,8 +13,8 @@ import (
 // The cache is passed explicitly so each provider instance is hermetic (no package-level state).
 // Errors are not cached — transient failures are retried on the next call.
 func GetCachedConnectorMetadata(ctx context.Context, client *fivetran.Client, cache *sync.Map, service string) (*metadata.ConnectorMetadata, error) {
-	if v, ok := cache.Load(service); ok {
-		return v.(*metadata.ConnectorMetadata), nil
+	if meta, ok, err := LoadCachedConnectorMetadata(cache, service); ok || err != nil {
+		return meta, err
 	}
 
 	resp, err := client.NewMetadataDetails().Service(service).Do(ctx)
@@ -24,5 +25,25 @@ func GetCachedConnectorMetadata(ctx context.Context, client *fivetran.Client, ca
 	meta := resp.Data.ConnectorMetadata
 	// LoadOrStore: concurrent fetches are idempotent; first stored value wins.
 	actual, _ := cache.LoadOrStore(service, &meta)
-	return actual.(*metadata.ConnectorMetadata), nil
+	return connectorMetadataCacheValue(service, actual)
+}
+
+func LoadCachedConnectorMetadata(cache *sync.Map, service string) (*metadata.ConnectorMetadata, bool, error) {
+	if cache == nil {
+		return nil, false, nil
+	}
+	v, ok := cache.Load(service)
+	if !ok {
+		return nil, false, nil
+	}
+	meta, err := connectorMetadataCacheValue(service, v)
+	return meta, true, err
+}
+
+func connectorMetadataCacheValue(service string, value interface{}) (*metadata.ConnectorMetadata, error) {
+	meta, ok := value.(*metadata.ConnectorMetadata)
+	if !ok {
+		return nil, fmt.Errorf("metadata cache contained unexpected type %T for service %q", value, service)
+	}
+	return meta, nil
 }

--- a/fivetran/framework/core/metadata_cache.go
+++ b/fivetran/framework/core/metadata_cache.go
@@ -13,8 +13,13 @@ import (
 // The cache is passed explicitly so each provider instance is hermetic (no package-level state).
 // Errors are not cached — transient failures are retried on the next call.
 func GetCachedConnectorMetadata(ctx context.Context, client *fivetran.Client, cache *sync.Map, service string) (*metadata.ConnectorMetadata, error) {
-	if meta, ok, err := LoadCachedConnectorMetadata(cache, service); ok || err != nil {
-		return meta, err
+	if cache != nil {
+		if meta, ok, err := LoadCachedConnectorMetadata(cache, service); ok || err != nil {
+			return meta, err
+		}
+	}
+	if client == nil {
+		return nil, fmt.Errorf("unconfigured Fivetran client")
 	}
 
 	resp, err := client.NewMetadataDetails().Service(service).Do(ctx)
@@ -23,6 +28,10 @@ func GetCachedConnectorMetadata(ctx context.Context, client *fivetran.Client, ca
 	}
 
 	meta := resp.Data.ConnectorMetadata
+	if cache == nil {
+		return &meta, nil
+	}
+
 	// LoadOrStore: concurrent fetches are idempotent; first stored value wins.
 	actual, _ := cache.LoadOrStore(service, &meta)
 	return connectorMetadataCacheValue(service, actual)

--- a/fivetran/framework/core/metadata_cache_test.go
+++ b/fivetran/framework/core/metadata_cache_test.go
@@ -71,6 +71,28 @@ func TestMetadataCache_HitReturnsCachedValue(t *testing.T) {
 	}
 }
 
+func TestMetadataCache_NilCacheFetchesWithoutCaching(t *testing.T) {
+	t.Parallel()
+	var callCount atomic.Int32
+	_, client := newMetadataServer(t, "google_sheets", &callCount, metadataDetailsBody)
+
+	m1, err := GetCachedConnectorMetadata(context.Background(), client, nil, "google_sheets")
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	m2, err := GetCachedConnectorMetadata(context.Background(), client, nil, "google_sheets")
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	if callCount.Load() != 2 {
+		t.Errorf("nil cache should fetch every time, got %d API calls", callCount.Load())
+	}
+	if m1 == m2 {
+		t.Error("nil cache calls should not return the same cached pointer")
+	}
+}
+
 func TestMetadataCache_TwoDistinctServicesMakeTwoCalls(t *testing.T) {
 	t.Parallel()
 	var count1, count2 atomic.Int32

--- a/fivetran/framework/core/metadata_field_status.go
+++ b/fivetran/framework/core/metadata_field_status.go
@@ -1,0 +1,35 @@
+package core
+
+import "github.com/fivetran/go-fivetran/metadata"
+
+const (
+	FieldStatusDevelopment         = "development"
+	FieldStatusPrivatePreview      = "private_preview"
+	FieldStatusGeneralAvailability = "general_availability"
+	FieldStatusSunset              = "sunset"
+)
+
+func MetadataFieldStatus(prop *metadata.Property) string {
+	if prop == nil {
+		return ""
+	}
+	return prop.FieldStatus
+}
+
+func IsKnownMetadataFieldStatus(status string) bool {
+	switch status {
+	case "", FieldStatusGeneralAvailability, FieldStatusPrivatePreview, FieldStatusDevelopment, FieldStatusSunset:
+		return true
+	default:
+		return false
+	}
+}
+
+func ShouldWarnForMetadataFieldStatus(prop *metadata.Property) bool {
+	switch MetadataFieldStatus(prop) {
+	case FieldStatusPrivatePreview, FieldStatusDevelopment, FieldStatusSunset:
+		return true
+	default:
+		return false
+	}
+}

--- a/fivetran/framework/core/provider_resource_data.go
+++ b/fivetran/framework/core/provider_resource_data.go
@@ -9,6 +9,7 @@ import (
 // ProviderResourceData is passed as ResourceData to all resources.
 // It carries the Fivetran client and the per-provider-instance metadata cache.
 type ProviderResourceData struct {
-	Client        *fivetran.Client
-	MetadataCache *sync.Map
+	Client                 *fivetran.Client
+	MetadataCache          *sync.Map
+	SkipPlanTimeValidation bool
 }

--- a/fivetran/framework/metadata_field_status.go
+++ b/fivetran/framework/metadata_field_status.go
@@ -1,35 +1,25 @@
 package framework
 
-import "github.com/fivetran/go-fivetran/metadata"
+import (
+	"github.com/fivetran/go-fivetran/metadata"
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core"
+)
 
 const (
-	FieldStatusDevelopment         = "development"
-	FieldStatusPrivatePreview      = "private_preview"
-	FieldStatusGeneralAvailability = "general_availability"
-	FieldStatusSunset              = "sunset"
+	FieldStatusDevelopment         = core.FieldStatusDevelopment
+	FieldStatusPrivatePreview      = core.FieldStatusPrivatePreview
+	FieldStatusGeneralAvailability = core.FieldStatusGeneralAvailability
+	FieldStatusSunset              = core.FieldStatusSunset
 )
 
 func MetadataFieldStatus(prop *metadata.Property) string {
-	if prop == nil {
-		return ""
-	}
-	return prop.FieldStatus
+	return core.MetadataFieldStatus(prop)
 }
 
 func IsKnownMetadataFieldStatus(status string) bool {
-	switch status {
-	case "", FieldStatusGeneralAvailability, FieldStatusPrivatePreview, FieldStatusDevelopment, FieldStatusSunset:
-		return true
-	default:
-		return false
-	}
+	return core.IsKnownMetadataFieldStatus(status)
 }
 
 func ShouldWarnForMetadataFieldStatus(prop *metadata.Property) bool {
-	switch MetadataFieldStatus(prop) {
-	case FieldStatusPrivatePreview, FieldStatusDevelopment, FieldStatusSunset:
-		return true
-	default:
-		return false
-	}
+	return core.ShouldWarnForMetadataFieldStatus(prop)
 }

--- a/fivetran/framework/provider.go
+++ b/fivetran/framework/provider.go
@@ -28,9 +28,10 @@ type fivetranProvider struct {
 }
 
 type fivetranProviderModel struct {
-	ApiKey    types.String `tfsdk:"api_key"`
-	ApiSecret types.String `tfsdk:"api_secret"`
-	ApiUrl    types.String `tfsdk:"api_url"`
+	ApiKey                 types.String `tfsdk:"api_key"`
+	ApiSecret              types.String `tfsdk:"api_secret"`
+	ApiUrl                 types.String `tfsdk:"api_url"`
+	SkipPlanTimeValidation types.Bool   `tfsdk:"skip_plan_time_validation"`
 }
 
 func FivetranProvider() provider.Provider {
@@ -60,6 +61,10 @@ func (p *fivetranProvider) Schema(ctx context.Context, req provider.SchemaReques
 			"api_key":    schema.StringAttribute{Optional: true},
 			"api_secret": schema.StringAttribute{Optional: true, Sensitive: true},
 			"api_url":    schema.StringAttribute{Optional: true},
+			"skip_plan_time_validation": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Skip metadata-backed plan-time validation for dynamic v2 resource fields. Use only as a temporary workaround when validation metadata is not available; invalid fields will fail later at apply time.",
+			},
 		},
 	}
 }
@@ -84,6 +89,10 @@ func (p *fivetranProvider) Configure(ctx context.Context, req provider.Configure
 	if data.ApiUrl.ValueString() != "" {
 		apiUrl = data.ApiUrl.ValueString()
 	}
+	skipPlanTimeValidation := false
+	if !data.SkipPlanTimeValidation.IsNull() && !data.SkipPlanTimeValidation.IsUnknown() {
+		skipPlanTimeValidation = data.SkipPlanTimeValidation.ValueBool()
+	}
 
 	// Init client
 	fivetranClient := fivetran.New(apiKey, apiSecret)
@@ -98,7 +107,11 @@ func (p *fivetranProvider) Configure(ctx context.Context, req provider.Configure
 
 	fivetranClient.CustomUserAgent("terraform-provider-fivetran/" + Version)
 	resp.DataSourceData = fivetranClient
-	resp.ResourceData = &core.ProviderResourceData{Client: fivetranClient, MetadataCache: p.metadataCache}
+	resp.ResourceData = &core.ProviderResourceData{
+		Client:                 fivetranClient,
+		MetadataCache:          p.metadataCache,
+		SkipPlanTimeValidation: skipPlanTimeValidation,
+	}
 	resp.ActionData = fivetranClient
 }
 

--- a/fivetran/framework/provider_test.go
+++ b/fivetran/framework/provider_test.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -11,7 +12,7 @@ import (
 func TestProviderSchemaIncludesSkipPlanTimeValidation(t *testing.T) {
 	t.Parallel()
 
-	p := FivetranProvider()
+	p := &fivetranProvider{metadataCache: &sync.Map{}}
 	var resp provider.SchemaResponse
 	p.Schema(context.Background(), provider.SchemaRequest{}, &resp)
 	if resp.Diagnostics.HasError() {

--- a/fivetran/framework/provider_test.go
+++ b/fivetran/framework/provider_test.go
@@ -1,0 +1,28 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	providerSchema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+)
+
+func TestProviderSchemaIncludesSkipPlanTimeValidation(t *testing.T) {
+	t.Parallel()
+
+	p := FivetranProvider()
+	var resp provider.SchemaResponse
+	p.Schema(context.Background(), provider.SchemaRequest{}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", resp.Diagnostics)
+	}
+
+	attr, ok := resp.Schema.Attributes["skip_plan_time_validation"].(providerSchema.BoolAttribute)
+	if !ok {
+		t.Fatalf("skip_plan_time_validation has type %T, want BoolAttribute", resp.Schema.Attributes["skip_plan_time_validation"])
+	}
+	if !attr.Optional || attr.Required {
+		t.Fatalf("skip_plan_time_validation mode = required:%v optional:%v, want optional only", attr.Required, attr.Optional)
+	}
+}

--- a/fivetran/framework/resources/connection_v2.go
+++ b/fivetran/framework/resources/connection_v2.go
@@ -324,8 +324,8 @@ func (r *connectionV2) connectorMetadata(ctx context.Context, service string) (*
 		cache = &sync.Map{}
 	}
 	if r.GetClient() == nil {
-		if v, ok := cache.Load(service); ok {
-			return v.(*metadata.ConnectorMetadata), nil
+		if meta, ok, err := core.LoadCachedConnectorMetadata(cache, service); ok || err != nil {
+			return meta, err
 		}
 		return nil, fmt.Errorf("unconfigured Fivetran client")
 	}

--- a/fivetran/framework/resources/connection_v2.go
+++ b/fivetran/framework/resources/connection_v2.go
@@ -323,6 +323,12 @@ func (r *connectionV2) connectorMetadata(ctx context.Context, service string) (*
 	if cache == nil {
 		cache = &sync.Map{}
 	}
+	if r.GetClient() == nil {
+		if v, ok := cache.Load(service); ok {
+			return v.(*metadata.ConnectorMetadata), nil
+		}
+		return nil, fmt.Errorf("unconfigured Fivetran client")
+	}
 	return core.GetCachedConnectorMetadata(ctx, r.GetClient(), cache, service)
 }
 

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -27,7 +27,7 @@ func (r *connectionV2) ValidateConfig(ctx context.Context, req resource.Validate
 		return
 	}
 
-	if data.Service.IsNull() || data.Service.IsUnknown() {
+	if data.Service.IsNull() || data.Service.IsUnknown() || data.Service.ValueString() == "" {
 		return
 	}
 
@@ -205,23 +205,30 @@ func isIntegerValue(value interface{}) bool {
 	case uint, uint8, uint16, uint32, uint64:
 		return true
 	case float32:
-		return math.Trunc(float64(v)) == float64(v)
+		f := float64(v)
+		return isFiniteFloat(f) && math.Trunc(f) == f
 	case float64:
-		return math.Trunc(v) == v
+		return isFiniteFloat(v) && math.Trunc(v) == v
 	default:
 		return false
 	}
 }
 
 func isNumberValue(value interface{}) bool {
-	switch value.(type) {
+	switch v := value.(type) {
 	case int, int8, int16, int32, int64:
 		return true
 	case uint, uint8, uint16, uint32, uint64:
 		return true
-	case float32, float64:
-		return true
+	case float32:
+		return isFiniteFloat(float64(v))
+	case float64:
+		return isFiniteFloat(v)
 	default:
 		return false
 	}
+}
+
+func isFiniteFloat(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
 }

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -38,7 +38,7 @@ func (r *connectionV2) ValidateConfig(ctx context.Context, req resource.Validate
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	if configMap == nil && authMap == nil {
+	if len(configMap) == 0 && len(authMap) == 0 {
 		return
 	}
 

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -96,7 +96,18 @@ func validateDynamicObject(values map[string]interface{}, slot *metadata.Propert
 }
 
 func validateDynamicValue(value interface{}, prop *metadata.Property, valuePath path.Path, diags *diag.Diagnostics) {
-	if value == nil || prop == nil {
+	if prop == nil {
+		return
+	}
+	if value == nil {
+		if prop.Nullable {
+			return
+		}
+		diags.AddAttributeError(
+			valuePath,
+			"Invalid Dynamic Field Value",
+			fmt.Sprintf("Field with metadata type %q does not allow null.", prop.Type),
+		)
 		return
 	}
 

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -69,7 +69,7 @@ func validateDynamicObject(values map[string]interface{}, slot *metadata.Propert
 	}
 
 	for name, value := range values {
-		prop := metadataSlotProp(slot, name)
+		prop := core.SlotProp(slot, name)
 		fieldPath := root.AtName(name)
 		if prop == nil {
 			diags.AddAttributeError(
@@ -203,11 +203,4 @@ func isNumberValue(value interface{}) bool {
 	default:
 		return false
 	}
-}
-
-func metadataSlotProp(slot *metadata.Property, key string) *metadata.Property {
-	if slot == nil || slot.Properties == nil {
-		return nil
-	}
-	return slot.Properties[key]
 }

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -31,7 +31,7 @@ func (r *connectionV2) ValidateConfig(ctx context.Context, req resource.Validate
 		return
 	}
 
-	configMap, authMap := r.dynamicPlanMaps(ctx, data, &resp.Diagnostics)
+	configMap, authMap := r.dynamicValidationMaps(ctx, data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -99,6 +99,9 @@ func validateDynamicValue(value interface{}, prop *metadata.Property, valuePath 
 	if prop == nil {
 		return
 	}
+	if core.IsDynamicUnknownValue(value) {
+		return
+	}
 	if value == nil {
 		if prop.Nullable {
 			return
@@ -154,6 +157,16 @@ func validateDynamicValue(value interface{}, prop *metadata.Property, valuePath 
 			fmt.Sprintf("Connector metadata returned unsupported type %q. Expected one of string, integer, number, boolean, array, or object.", prop.Type),
 		)
 	}
+}
+
+func (r *connectionV2) dynamicValidationMaps(ctx context.Context, data model.ConnectionV2ResourceModel, diags *diag.Diagnostics) (map[string]interface{}, map[string]interface{}) {
+	configMap, configDiags := core.DynamicToMapPreserveUnknown(ctx, data.Config)
+	diags.Append(configDiags...)
+
+	authMap, authDiags := core.DynamicToMapPreserveUnknown(ctx, data.Auth)
+	diags.Append(authDiags...)
+
+	return configMap, authMap
 }
 
 func validateStringValue(value interface{}, prop *metadata.Property, valuePath path.Path, diags *diag.Diagnostics) {

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -31,10 +31,7 @@ func (r *connectionV2) ValidateConfig(ctx context.Context, req resource.Validate
 		return
 	}
 
-	configMap, configDiags := core.DynamicToMap(ctx, data.Config)
-	resp.Diagnostics.Append(configDiags...)
-	authMap, authDiags := core.DynamicToMap(ctx, data.Auth)
-	resp.Diagnostics.Append(authDiags...)
+	configMap, authMap := r.dynamicPlanMaps(ctx, data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -89,8 +86,8 @@ func validateDynamicObject(values map[string]interface{}, slot *metadata.Propert
 		} else if core.ShouldWarnForMetadataFieldStatus(prop) {
 			diags.AddAttributeWarning(
 				fieldPath,
-				"Non-GA Dynamic Field",
-				fmt.Sprintf("Field %q is marked as %q in connector metadata. It is accepted because the metadata endpoint returned it for this account, but availability may change before general availability.", name, prop.FieldStatus),
+				"Non-Standard Dynamic Field",
+				fmt.Sprintf("Field %q is marked as %q in connector metadata. It is accepted because the metadata endpoint returned it for this account, but its availability or behavior may change, including potential removal for sunset fields.", name, prop.FieldStatus),
 			)
 		}
 

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -1,0 +1,213 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/fivetran/go-fivetran/metadata"
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core"
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+var _ resource.ResourceWithValidateConfig = &connectionV2{}
+
+func (r *connectionV2) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	if r.GetSkipPlanTimeValidation() {
+		return
+	}
+
+	var data model.ConnectionV2ResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.Service.IsNull() || data.Service.IsUnknown() {
+		return
+	}
+
+	configMap, configDiags := core.DynamicToMap(ctx, data.Config)
+	resp.Diagnostics.Append(configDiags...)
+	authMap, authDiags := core.DynamicToMap(ctx, data.Auth)
+	resp.Diagnostics.Append(authDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if configMap == nil && authMap == nil {
+		return
+	}
+
+	meta, err := r.connectorMetadata(ctx, data.Service.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Validate Connection V2 Configuration",
+			fmt.Sprintf("Unable to fetch metadata for service %q. Terraform cannot safely validate dynamic config/auth fields without metadata. Fix metadata access or set provider skip_plan_time_validation = true to bypass this check temporarily. Original error: %v", data.Service.ValueString(), err),
+		)
+		return
+	}
+
+	validateDynamicObject(configMap, &meta.Config, path.Root("config"), &resp.Diagnostics)
+	validateDynamicObject(authMap, &meta.Auth, path.Root("auth"), &resp.Diagnostics)
+}
+
+func validateDynamicObject(values map[string]interface{}, slot *metadata.Property, root path.Path, diags *diag.Diagnostics) {
+	if values == nil {
+		return
+	}
+	if slot == nil {
+		diags.AddAttributeError(
+			root,
+			"Unsupported Dynamic Field",
+			"Metadata does not define this dynamic object.",
+		)
+		return
+	}
+
+	for name, value := range values {
+		prop := metadataSlotProp(slot, name)
+		fieldPath := root.AtName(name)
+		if prop == nil {
+			diags.AddAttributeError(
+				fieldPath,
+				"Unsupported Dynamic Field",
+				fmt.Sprintf("Metadata for this service does not define field %q.", name),
+			)
+			continue
+		}
+
+		if !core.IsKnownMetadataFieldStatus(prop.FieldStatus) {
+			diags.AddAttributeWarning(
+				fieldPath,
+				"Unknown Metadata Field Status",
+				fmt.Sprintf("Field %q has unknown metadata fieldStatus %q. Terraform will validate the field shape, but the field availability may need provider support in the future.", name, prop.FieldStatus),
+			)
+		} else if core.ShouldWarnForMetadataFieldStatus(prop) {
+			diags.AddAttributeWarning(
+				fieldPath,
+				"Non-GA Dynamic Field",
+				fmt.Sprintf("Field %q is marked as %q in connector metadata. It is accepted because the metadata endpoint returned it for this account, but availability may change before general availability.", name, prop.FieldStatus),
+			)
+		}
+
+		validateDynamicValue(value, prop, fieldPath, diags)
+	}
+}
+
+func validateDynamicValue(value interface{}, prop *metadata.Property, valuePath path.Path, diags *diag.Diagnostics) {
+	if value == nil || prop == nil {
+		return
+	}
+
+	switch prop.Type {
+	case "string":
+		validateStringValue(value, prop, valuePath, diags)
+	case "integer":
+		if !isIntegerValue(value) {
+			addTypeError(valuePath, prop.Type, value, diags)
+		}
+	case "number":
+		if !isNumberValue(value) {
+			addTypeError(valuePath, prop.Type, value, diags)
+		}
+	case "boolean":
+		if _, ok := value.(bool); !ok {
+			addTypeError(valuePath, prop.Type, value, diags)
+		}
+	case "array":
+		items, ok := value.([]interface{})
+		if !ok {
+			addTypeError(valuePath, prop.Type, value, diags)
+			return
+		}
+		if prop.Items == nil {
+			return
+		}
+		for i, item := range items {
+			validateDynamicValue(item, prop.Items, valuePath.AtListIndex(i), diags)
+		}
+	case "object":
+		nested, ok := value.(map[string]interface{})
+		if !ok {
+			addTypeError(valuePath, prop.Type, value, diags)
+			return
+		}
+		validateDynamicObject(nested, prop, valuePath, diags)
+	case "":
+		return
+	default:
+		diags.AddAttributeError(
+			valuePath,
+			"Unknown Metadata Field Type",
+			fmt.Sprintf("Connector metadata returned unsupported type %q. Expected one of string, integer, number, boolean, array, or object.", prop.Type),
+		)
+	}
+}
+
+func validateStringValue(value interface{}, prop *metadata.Property, valuePath path.Path, diags *diag.Diagnostics) {
+	stringValue, ok := value.(string)
+	if !ok {
+		addTypeError(valuePath, prop.Type, value, diags)
+		return
+	}
+	if len(prop.Enum) == 0 {
+		return
+	}
+	for _, allowed := range prop.Enum {
+		if stringValue == allowed {
+			return
+		}
+	}
+	diags.AddAttributeError(
+		valuePath,
+		"Invalid Dynamic Field Value",
+		fmt.Sprintf("Value %q is not allowed. Allowed values: %s.", stringValue, strings.Join(prop.Enum, ", ")),
+	)
+}
+
+func addTypeError(valuePath path.Path, expected string, value interface{}, diags *diag.Diagnostics) {
+	diags.AddAttributeError(
+		valuePath,
+		"Invalid Dynamic Field Type",
+		fmt.Sprintf("Expected metadata type %q, got Terraform value type %T.", expected, value),
+	)
+}
+
+func isIntegerValue(value interface{}) bool {
+	switch v := value.(type) {
+	case int, int8, int16, int32, int64:
+		return true
+	case uint, uint8, uint16, uint32, uint64:
+		return true
+	case float32:
+		return math.Trunc(float64(v)) == float64(v)
+	case float64:
+		return math.Trunc(v) == v
+	default:
+		return false
+	}
+}
+
+func isNumberValue(value interface{}) bool {
+	switch value.(type) {
+	case int, int8, int16, int32, int64:
+		return true
+	case uint, uint8, uint16, uint32, uint64:
+		return true
+	case float32, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func metadataSlotProp(slot *metadata.Property, key string) *metadata.Property {
+	if slot == nil || slot.Properties == nil {
+		return nil
+	}
+	return slot.Properties[key]
+}

--- a/fivetran/framework/resources/connection_v2_validate_test.go
+++ b/fivetran/framework/resources/connection_v2_validate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core"
 	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
 	fivetranSchema "github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/schema"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -348,6 +349,39 @@ func TestConnectionV2ValidateConfigEarlyReturns(t *testing.T) {
 	}
 }
 
+func TestConnectionV2ValidateConfigSkipsUnknownNestedValue(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cache := &sync.Map{}
+	cache.Store("google_ads", &metadata.ConnectorMetadata{
+		Config: metadata.Property{Properties: map[string]*metadata.Property{
+			"schema": {Type: "string"},
+		}},
+	})
+
+	configObject, diags := types.ObjectValue(
+		map[string]attr.Type{"schema": types.StringType},
+		map[string]attr.Value{"schema": types.StringUnknown()},
+	)
+	if diags.HasError() {
+		t.Fatalf("config object diagnostics: %v", diags)
+	}
+
+	r := configuredConnectionV2ForValidation(t, false, cache)
+	req := connectionV2ValidateConfigRequestWithDynamic(
+		t,
+		types.StringValue("google_ads"),
+		types.DynamicValue(configObject),
+		types.DynamicNull(),
+	)
+
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	assertNoDiagnostics(t, resp.Diagnostics)
+}
+
 func TestConnectionV2ValidateConfigUsesMetadataCache(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -548,6 +582,13 @@ func connectionV2ValidateConfigRequestWithService(t *testing.T, service types.St
 			t.Fatalf("auth dynamic diagnostics: %v", diags)
 		}
 	}
+
+	return connectionV2ValidateConfigRequestWithDynamic(t, service, configValue, authValue)
+}
+
+func connectionV2ValidateConfigRequestWithDynamic(t *testing.T, service types.String, configValue, authValue types.Dynamic) resource.ValidateConfigRequest {
+	t.Helper()
+	ctx := context.Background()
 
 	data := model.ConnectionV2ResourceModel{
 		Id:                      types.StringNull(),

--- a/fivetran/framework/resources/connection_v2_validate_test.go
+++ b/fivetran/framework/resources/connection_v2_validate_test.go
@@ -1,0 +1,357 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+
+	fivetran "github.com/fivetran/go-fivetran"
+	"github.com/fivetran/go-fivetran/metadata"
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core"
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
+	fivetranSchema "github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValidateDynamicObjectAcceptsKnownFields(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	validateDynamicObject(map[string]interface{}{
+		"schema":  "app",
+		"enabled": true,
+		"count":   int64(3),
+		"mode":    "AllAccounts",
+		"nested": map[string]interface{}{
+			"table": "events",
+		},
+		"reports": []interface{}{
+			map[string]interface{}{"report_type": "campaign"},
+		},
+	}, &metadata.Property{
+		Properties: map[string]*metadata.Property{
+			"schema":  {Type: "string"},
+			"enabled": {Type: "boolean"},
+			"count":   {Type: "integer"},
+			"mode":    {Type: "string", Enum: []string{"AllAccounts", "SpecificAccounts"}},
+			"nested": {
+				Type: "object",
+				Properties: map[string]*metadata.Property{
+					"table": {Type: "string"},
+				},
+			},
+			"reports": {
+				Type: "array",
+				Items: &metadata.Property{
+					Type: "object",
+					Properties: map[string]*metadata.Property{
+						"report_type": {Type: "string"},
+					},
+				},
+			},
+		},
+	}, path.Root("config"), &diags)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected validation errors: %v", diags)
+	}
+}
+
+func TestValidateDynamicObjectRejectsUnknownField(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	validateDynamicObject(
+		map[string]interface{}{"dog": "good_boy"},
+		&metadata.Property{Properties: map[string]*metadata.Property{"schema": {Type: "string"}}},
+		path.Root("config"),
+		&diags,
+	)
+
+	if diags.ErrorsCount() != 1 {
+		t.Fatalf("errors = %d, want 1: %v", diags.ErrorsCount(), diags)
+	}
+}
+
+func TestValidateDynamicObjectRejectsWrongType(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	validateDynamicObject(
+		map[string]interface{}{"schema": true},
+		&metadata.Property{Properties: map[string]*metadata.Property{"schema": {Type: "string"}}},
+		path.Root("config"),
+		&diags,
+	)
+
+	if diags.ErrorsCount() != 1 {
+		t.Fatalf("errors = %d, want 1: %v", diags.ErrorsCount(), diags)
+	}
+}
+
+func TestValidateDynamicObjectRejectsInvalidEnum(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	validateDynamicObject(
+		map[string]interface{}{"sync_mode": "Nope"},
+		&metadata.Property{Properties: map[string]*metadata.Property{
+			"sync_mode": {Type: "string", Enum: []string{"AllAccounts", "SpecificAccounts"}},
+		}},
+		path.Root("config"),
+		&diags,
+	)
+
+	if diags.ErrorsCount() != 1 {
+		t.Fatalf("errors = %d, want 1: %v", diags.ErrorsCount(), diags)
+	}
+}
+
+func TestValidateDynamicObjectRejectsUnknownMetadataType(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	validateDynamicObject(
+		map[string]interface{}{"schema": "app"},
+		&metadata.Property{Properties: map[string]*metadata.Property{
+			"schema": {Type: "wat"},
+		}},
+		path.Root("config"),
+		&diags,
+	)
+
+	if diags.ErrorsCount() != 1 {
+		t.Fatalf("errors = %d, want 1: %v", diags.ErrorsCount(), diags)
+	}
+}
+
+func TestValidateDynamicObjectWarnsForNonGAFieldStatus(t *testing.T) {
+	t.Parallel()
+
+	var diags diag.Diagnostics
+	validateDynamicObject(
+		map[string]interface{}{"preview_field": "value"},
+		&metadata.Property{Properties: map[string]*metadata.Property{
+			"preview_field": {Type: "string", FieldStatus: "private_preview"},
+		}},
+		path.Root("config"),
+		&diags,
+	)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected validation errors: %v", diags)
+	}
+	if diags.WarningsCount() != 1 {
+		t.Fatalf("warnings = %d, want 1: %v", diags.WarningsCount(), diags)
+	}
+}
+
+func TestConnectionV2ValidateConfigUsesMetadataCache(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cache := &sync.Map{}
+	cache.Store("google_ads", &metadata.ConnectorMetadata{
+		Config: metadata.Property{Properties: map[string]*metadata.Property{
+			"schema":    {Type: "string"},
+			"sync_mode": {Type: "string", Enum: []string{"AllAccounts", "SpecificAccounts"}},
+		}},
+		Auth: metadata.Property{Properties: map[string]*metadata.Property{
+			"refresh_token": {Type: "string"},
+		}},
+	})
+
+	r := configuredConnectionV2ForValidation(t, false, cache)
+	req := connectionV2ValidateConfigRequest(t, "google_ads",
+		map[string]interface{}{"schema": "app", "sync_mode": "AllAccounts"},
+		map[string]interface{}{"refresh_token": "secret"},
+	)
+
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected validation errors: %v", resp.Diagnostics)
+	}
+}
+
+func TestConnectionV2ValidateConfigReportsMetadataFetchFailure(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	client := fivetran.New("key", "secret")
+	client.SetHttpClient(errorHTTPClient{})
+
+	r := configuredConnectionV2ForValidationWithClient(t, false, &sync.Map{}, client)
+	req := connectionV2ValidateConfigRequest(t, "google_ads",
+		map[string]interface{}{"schema": "app"},
+		nil,
+	)
+
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	if resp.Diagnostics.ErrorsCount() != 1 {
+		t.Fatalf("errors = %d, want 1: %v", resp.Diagnostics.ErrorsCount(), resp.Diagnostics)
+	}
+}
+
+func TestConnectionV2ValidateConfigReportsUnconfiguredClient(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	r := configuredConnectionV2ForValidation(t, false, &sync.Map{})
+	req := connectionV2ValidateConfigRequest(t, "google_ads",
+		map[string]interface{}{"schema": "app"},
+		nil,
+	)
+
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	if resp.Diagnostics.ErrorsCount() != 1 {
+		t.Fatalf("errors = %d, want 1: %v", resp.Diagnostics.ErrorsCount(), resp.Diagnostics)
+	}
+}
+
+func TestConnectionV2ValidateConfigReportsMetadataValidationErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cache := &sync.Map{}
+	cache.Store("google_ads", &metadata.ConnectorMetadata{
+		Config: metadata.Property{Properties: map[string]*metadata.Property{
+			"sync_mode": {Type: "string", Enum: []string{"AllAccounts", "SpecificAccounts"}},
+		}},
+	})
+
+	r := configuredConnectionV2ForValidation(t, false, cache)
+	req := connectionV2ValidateConfigRequest(t, "google_ads",
+		map[string]interface{}{"dog": "good_boy", "sync_mode": "Nope"},
+		nil,
+	)
+
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	if resp.Diagnostics.ErrorsCount() != 2 {
+		t.Fatalf("errors = %d, want 2: %v", resp.Diagnostics.ErrorsCount(), resp.Diagnostics)
+	}
+}
+
+func TestConnectionV2ValidateConfigSkipReturnsBeforeConfigDecode(t *testing.T) {
+	t.Parallel()
+
+	r := configuredConnectionV2ForValidation(t, true, nil)
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(context.Background(), resource.ValidateConfigRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("skip_plan_time_validation should return before config decode, got: %v", resp.Diagnostics)
+	}
+}
+
+func configuredConnectionV2ForValidation(t *testing.T, skip bool, cache *sync.Map) *connectionV2 {
+	t.Helper()
+
+	return configuredConnectionV2ForValidationWithClient(t, skip, cache, nil)
+}
+
+func configuredConnectionV2ForValidationWithClient(t *testing.T, skip bool, cache *sync.Map, client *fivetran.Client) *connectionV2 {
+	t.Helper()
+
+	r := &connectionV2{}
+	var resp resource.ConfigureResponse
+	r.Configure(context.Background(), resource.ConfigureRequest{
+		ProviderData: &core.ProviderResourceData{
+			Client:                 client,
+			MetadataCache:          cache,
+			SkipPlanTimeValidation: skip,
+		},
+	}, &resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("configure diagnostics: %v", resp.Diagnostics)
+	}
+	return r
+}
+
+type errorHTTPClient struct{}
+
+func (errorHTTPClient) Do(*http.Request) (*http.Response, error) {
+	return nil, errors.New("metadata unavailable")
+}
+
+func connectionV2ValidateConfigRequest(t *testing.T, service string, config, auth map[string]interface{}) resource.ValidateConfigRequest {
+	t.Helper()
+	ctx := context.Background()
+
+	configValue := types.DynamicNull()
+	if config != nil {
+		var diags diag.Diagnostics
+		configValue, diags = core.MapToDynamic(ctx, config)
+		if diags.HasError() {
+			t.Fatalf("config dynamic diagnostics: %v", diags)
+		}
+	}
+
+	authValue := types.DynamicNull()
+	if auth != nil {
+		var diags diag.Diagnostics
+		authValue, diags = core.MapToDynamic(ctx, auth)
+		if diags.HasError() {
+			t.Fatalf("auth dynamic diagnostics: %v", diags)
+		}
+	}
+
+	data := model.ConnectionV2ResourceModel{
+		Id:                      types.StringNull(),
+		Name:                    types.StringNull(),
+		ConnectedBy:             types.StringNull(),
+		CreatedAt:               types.StringNull(),
+		GroupId:                 types.StringValue("group_id"),
+		Service:                 types.StringValue(service),
+		Config:                  configValue,
+		Auth:                    authValue,
+		SucceededAt:             types.StringNull(),
+		FailedAt:                types.StringNull(),
+		ServiceVersion:          types.StringNull(),
+		SyncFrequency:           types.Int64Null(),
+		ScheduleType:            types.StringNull(),
+		PauseAfterTrial:         types.BoolNull(),
+		DailySyncTime:           types.StringNull(),
+		ProxyAgentId:            types.StringNull(),
+		NetworkingMethod:        types.StringNull(),
+		HybridDeploymentAgentId: types.StringNull(),
+		PrivateLinkId:           types.StringNull(),
+		DataDelaySensitivity:    types.StringNull(),
+		DataDelayThreshold:      types.Int64Null(),
+		RunSetupTests:           types.BoolNull(),
+		TrustCertificates:       types.BoolNull(),
+		TrustFingerprints:       types.BoolNull(),
+		Status:                  types.ObjectNull(model.ConnectionV2StatusAttrTypes()),
+	}
+
+	var object types.Object
+	diags := tfsdk.ValueFrom(ctx, data, types.ObjectType{AttrTypes: model.ConnectionV2ResourceModelAttrTypes()}, &object)
+	if diags.HasError() {
+		t.Fatalf("ValueFrom diagnostics: %v", diags)
+	}
+
+	raw, err := object.ToTerraformValue(ctx)
+	if err != nil {
+		t.Fatalf("converting config to Terraform value: %v", err)
+	}
+
+	return resource.ValidateConfigRequest{
+		Config: tfsdk.Config{
+			Raw:    raw,
+			Schema: fivetranSchema.ConnectionV2ResourceSchema(),
+		},
+	}
+}

--- a/fivetran/framework/resources/connection_v2_validate_test.go
+++ b/fivetran/framework/resources/connection_v2_validate_test.go
@@ -113,6 +113,116 @@ func TestValidateDynamicObjectRejectsInvalidEnum(t *testing.T) {
 	}
 }
 
+func TestValidateDynamicValueTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		prop       *metadata.Property
+		value      interface{}
+		wantErrors int
+	}{
+		{name: "string accepts string", prop: &metadata.Property{Type: "string"}, value: "app"},
+		{name: "string rejects bool", prop: &metadata.Property{Type: "string"}, value: true, wantErrors: 1},
+		{name: "string rejects int", prop: &metadata.Property{Type: "string"}, value: int64(1), wantErrors: 1},
+		{name: "string rejects object", prop: &metadata.Property{Type: "string"}, value: map[string]interface{}{"schema": "app"}, wantErrors: 1},
+		{name: "integer accepts int64", prop: &metadata.Property{Type: "integer"}, value: int64(3)},
+		{name: "integer accepts exact float64", prop: &metadata.Property{Type: "integer"}, value: float64(3)},
+		{name: "integer rejects non-integer float64", prop: &metadata.Property{Type: "integer"}, value: float64(3.5), wantErrors: 1},
+		{name: "integer rejects string", prop: &metadata.Property{Type: "integer"}, value: "3", wantErrors: 1},
+		{name: "number accepts int64", prop: &metadata.Property{Type: "number"}, value: int64(3)},
+		{name: "number accepts float64", prop: &metadata.Property{Type: "number"}, value: float64(3.5)},
+		{name: "number rejects string", prop: &metadata.Property{Type: "number"}, value: "3.5", wantErrors: 1},
+		{name: "number rejects bool", prop: &metadata.Property{Type: "number"}, value: true, wantErrors: 1},
+		{name: "boolean accepts bool", prop: &metadata.Property{Type: "boolean"}, value: true},
+		{name: "boolean rejects string", prop: &metadata.Property{Type: "boolean"}, value: "true", wantErrors: 1},
+		{name: "empty metadata type is tolerated", prop: &metadata.Property{Type: ""}, value: map[string]interface{}{"schema": "app"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var diags diag.Diagnostics
+			validateDynamicValue(tt.value, tt.prop, path.Root("config").AtName("field"), &diags)
+			assertErrorCount(t, diags, tt.wantErrors)
+			assertWarningCount(t, diags, 0)
+		})
+	}
+}
+
+func TestValidateDynamicValueCollections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		prop       *metadata.Property
+		value      interface{}
+		wantErrors int
+	}{
+		{
+			name:  "array accepts valid item types",
+			prop:  &metadata.Property{Type: "array", Items: &metadata.Property{Type: "string"}},
+			value: []interface{}{"one", "two"},
+		},
+		{
+			name:       "array rejects non-array value",
+			prop:       &metadata.Property{Type: "array", Items: &metadata.Property{Type: "string"}},
+			value:      "not-array",
+			wantErrors: 1,
+		},
+		{
+			name:       "array rejects invalid item type",
+			prop:       &metadata.Property{Type: "array", Items: &metadata.Property{Type: "string"}},
+			value:      []interface{}{"one", true},
+			wantErrors: 1,
+		},
+		{
+			name:  "array with nil items skips item validation",
+			prop:  &metadata.Property{Type: "array"},
+			value: []interface{}{"one", true, map[string]interface{}{"nested": "value"}},
+		},
+		{
+			name: "object accepts nested map",
+			prop: &metadata.Property{Type: "object", Properties: map[string]*metadata.Property{
+				"table": {Type: "string"},
+			}},
+			value: map[string]interface{}{"table": "events"},
+		},
+		{
+			name:       "object rejects non-object value",
+			prop:       &metadata.Property{Type: "object", Properties: map[string]*metadata.Property{"table": {Type: "string"}}},
+			value:      "not-object",
+			wantErrors: 1,
+		},
+		{
+			name:       "nested object rejects unknown field",
+			prop:       &metadata.Property{Type: "object", Properties: map[string]*metadata.Property{"table": {Type: "string"}}},
+			value:      map[string]interface{}{"dog": "good_boy"},
+			wantErrors: 1,
+		},
+		{
+			name:       "nested object rejects wrong field type",
+			prop:       &metadata.Property{Type: "object", Properties: map[string]*metadata.Property{"table": {Type: "string"}}},
+			value:      map[string]interface{}{"table": true},
+			wantErrors: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var diags diag.Diagnostics
+			validateDynamicValue(tt.value, tt.prop, path.Root("config").AtName("field"), &diags)
+			assertErrorCount(t, diags, tt.wantErrors)
+			assertWarningCount(t, diags, 0)
+		})
+	}
+}
+
 func TestValidateDynamicObjectRejectsUnknownMetadataType(t *testing.T) {
 	t.Parallel()
 
@@ -128,6 +238,43 @@ func TestValidateDynamicObjectRejectsUnknownMetadataType(t *testing.T) {
 
 	if diags.ErrorsCount() != 1 {
 		t.Fatalf("errors = %d, want 1: %v", diags.ErrorsCount(), diags)
+	}
+}
+
+func TestValidateDynamicObjectFieldStatuses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fieldStatus  string
+		wantWarnings int
+	}{
+		{name: "missing status"},
+		{name: "general availability", fieldStatus: core.FieldStatusGeneralAvailability},
+		{name: "private preview", fieldStatus: core.FieldStatusPrivatePreview, wantWarnings: 1},
+		{name: "development", fieldStatus: core.FieldStatusDevelopment, wantWarnings: 1},
+		{name: "sunset", fieldStatus: core.FieldStatusSunset, wantWarnings: 1},
+		{name: "unknown status", fieldStatus: "some_future_status", wantWarnings: 1},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var diags diag.Diagnostics
+			validateDynamicObject(
+				map[string]interface{}{"field": "value"},
+				&metadata.Property{Properties: map[string]*metadata.Property{
+					"field": {Type: "string", FieldStatus: tt.fieldStatus},
+				}},
+				path.Root("config"),
+				&diags,
+			)
+
+			assertErrorCount(t, diags, 0)
+			assertWarningCount(t, diags, tt.wantWarnings)
+		})
 	}
 }
 
@@ -149,6 +296,53 @@ func TestValidateDynamicObjectWarnsForNonGAFieldStatus(t *testing.T) {
 	}
 	if diags.WarningsCount() != 1 {
 		t.Fatalf("warnings = %d, want 1: %v", diags.WarningsCount(), diags)
+	}
+}
+
+func TestConnectionV2ValidateConfigEarlyReturns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		service types.String
+		config  map[string]interface{}
+		auth    map[string]interface{}
+	}{
+		{
+			name:    "null config and auth skips metadata fetch",
+			service: types.StringValue("google_ads"),
+		},
+		{
+			name:    "empty config and auth skips metadata fetch",
+			service: types.StringValue("google_ads"),
+			config:  map[string]interface{}{},
+			auth:    map[string]interface{}{},
+		},
+		{
+			name:    "null service skips metadata fetch",
+			service: types.StringNull(),
+			config:  map[string]interface{}{"schema": "app"},
+		},
+		{
+			name:    "unknown service skips metadata fetch",
+			service: types.StringUnknown(),
+			config:  map[string]interface{}{"schema": "app"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := configuredConnectionV2ForValidation(t, false, &sync.Map{})
+			req := connectionV2ValidateConfigRequestWithService(t, tt.service, tt.config, tt.auth)
+
+			var resp resource.ValidateConfigResponse
+			r.ValidateConfig(context.Background(), req, &resp)
+
+			assertNoDiagnostics(t, resp.Diagnostics)
+		})
 	}
 }
 
@@ -328,6 +522,11 @@ func (errorHTTPClient) Do(*http.Request) (*http.Response, error) {
 
 func connectionV2ValidateConfigRequest(t *testing.T, service string, config, auth map[string]interface{}) resource.ValidateConfigRequest {
 	t.Helper()
+	return connectionV2ValidateConfigRequestWithService(t, types.StringValue(service), config, auth)
+}
+
+func connectionV2ValidateConfigRequestWithService(t *testing.T, service types.String, config, auth map[string]interface{}) resource.ValidateConfigRequest {
+	t.Helper()
 	ctx := context.Background()
 
 	configValue := types.DynamicNull()
@@ -354,7 +553,7 @@ func connectionV2ValidateConfigRequest(t *testing.T, service string, config, aut
 		ConnectedBy:             types.StringNull(),
 		CreatedAt:               types.StringNull(),
 		GroupId:                 types.StringValue("group_id"),
-		Service:                 types.StringValue(service),
+		Service:                 service,
 		Config:                  configValue,
 		Auth:                    authValue,
 		SucceededAt:             types.StringNull(),
@@ -392,5 +591,26 @@ func connectionV2ValidateConfigRequest(t *testing.T, service string, config, aut
 			Raw:    raw,
 			Schema: fivetranSchema.ConnectionV2ResourceSchema(),
 		},
+	}
+}
+
+func assertNoDiagnostics(t *testing.T, diags diag.Diagnostics) {
+	t.Helper()
+	if diags.HasError() || diags.WarningsCount() > 0 {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+}
+
+func assertErrorCount(t *testing.T, diags diag.Diagnostics, want int) {
+	t.Helper()
+	if diags.ErrorsCount() != want {
+		t.Fatalf("errors = %d, want %d: %v", diags.ErrorsCount(), want, diags)
+	}
+}
+
+func assertWarningCount(t *testing.T, diags diag.Diagnostics, want int) {
+	t.Helper()
+	if diags.WarningsCount() != want {
+		t.Fatalf("warnings = %d, want %d: %v", diags.WarningsCount(), want, diags)
 	}
 }

--- a/fivetran/framework/resources/connection_v2_validate_test.go
+++ b/fivetran/framework/resources/connection_v2_validate_test.go
@@ -136,6 +136,8 @@ func TestValidateDynamicValueTypes(t *testing.T) {
 		{name: "number rejects bool", prop: &metadata.Property{Type: "number"}, value: true, wantErrors: 1},
 		{name: "boolean accepts bool", prop: &metadata.Property{Type: "boolean"}, value: true},
 		{name: "boolean rejects string", prop: &metadata.Property{Type: "boolean"}, value: "true", wantErrors: 1},
+		{name: "null rejects non-nullable field", prop: &metadata.Property{Type: "string"}, value: nil, wantErrors: 1},
+		{name: "null accepts nullable field", prop: &metadata.Property{Type: "string", Nullable: true}, value: nil},
 		{name: "empty metadata type is tolerated", prop: &metadata.Property{Type: ""}, value: map[string]interface{}{"schema": "app"}},
 	}
 

--- a/fivetran/framework/resources/connection_v2_validate_test.go
+++ b/fivetran/framework/resources/connection_v2_validate_test.go
@@ -238,6 +238,27 @@ func TestConnectionV2ValidateConfigReportsUnconfiguredClient(t *testing.T) {
 	}
 }
 
+func TestConnectionV2ValidateConfigReportsUnexpectedMetadataCacheType(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	cache := &sync.Map{}
+	cache.Store("google_ads", "not metadata")
+
+	r := configuredConnectionV2ForValidation(t, false, cache)
+	req := connectionV2ValidateConfigRequest(t, "google_ads",
+		map[string]interface{}{"schema": "app"},
+		nil,
+	)
+
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	if resp.Diagnostics.ErrorsCount() != 1 {
+		t.Fatalf("errors = %d, want 1: %v", resp.Diagnostics.ErrorsCount(), resp.Diagnostics)
+	}
+}
+
 func TestConnectionV2ValidateConfigReportsMetadataValidationErrors(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/fivetran/framework/resources/connection_v2_validate_test.go
+++ b/fivetran/framework/resources/connection_v2_validate_test.go
@@ -202,6 +202,24 @@ func TestConnectionV2ValidateConfigReportsMetadataFetchFailure(t *testing.T) {
 	}
 }
 
+func TestConnectionV2ValidateConfigSkipsMetadataFetchForEmptyDynamicObjects(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	r := configuredConnectionV2ForValidation(t, false, &sync.Map{})
+	req := connectionV2ValidateConfigRequest(t, "google_ads",
+		map[string]interface{}{},
+		map[string]interface{}{},
+	)
+
+	var resp resource.ValidateConfigResponse
+	r.ValidateConfig(ctx, req, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected validation errors: %v", resp.Diagnostics)
+	}
+}
+
 func TestConnectionV2ValidateConfigReportsUnconfiguredClient(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/fivetran/framework/resources/connection_v2_validate_test.go
+++ b/fivetran/framework/resources/connection_v2_validate_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 	"errors"
+	"math"
 	"net/http"
 	"sync"
 	"testing"
@@ -130,9 +131,15 @@ func TestValidateDynamicValueTypes(t *testing.T) {
 		{name: "integer accepts int64", prop: &metadata.Property{Type: "integer"}, value: int64(3)},
 		{name: "integer accepts exact float64", prop: &metadata.Property{Type: "integer"}, value: float64(3)},
 		{name: "integer rejects non-integer float64", prop: &metadata.Property{Type: "integer"}, value: float64(3.5), wantErrors: 1},
+		{name: "integer rejects positive infinity", prop: &metadata.Property{Type: "integer"}, value: math.Inf(1), wantErrors: 1},
+		{name: "integer rejects negative infinity", prop: &metadata.Property{Type: "integer"}, value: math.Inf(-1), wantErrors: 1},
+		{name: "integer rejects NaN", prop: &metadata.Property{Type: "integer"}, value: math.NaN(), wantErrors: 1},
 		{name: "integer rejects string", prop: &metadata.Property{Type: "integer"}, value: "3", wantErrors: 1},
 		{name: "number accepts int64", prop: &metadata.Property{Type: "number"}, value: int64(3)},
 		{name: "number accepts float64", prop: &metadata.Property{Type: "number"}, value: float64(3.5)},
+		{name: "number rejects positive infinity", prop: &metadata.Property{Type: "number"}, value: math.Inf(1), wantErrors: 1},
+		{name: "number rejects negative infinity", prop: &metadata.Property{Type: "number"}, value: math.Inf(-1), wantErrors: 1},
+		{name: "number rejects NaN", prop: &metadata.Property{Type: "number"}, value: math.NaN(), wantErrors: 1},
 		{name: "number rejects string", prop: &metadata.Property{Type: "number"}, value: "3.5", wantErrors: 1},
 		{name: "number rejects bool", prop: &metadata.Property{Type: "number"}, value: true, wantErrors: 1},
 		{name: "boolean accepts bool", prop: &metadata.Property{Type: "boolean"}, value: true},
@@ -329,6 +336,11 @@ func TestConnectionV2ValidateConfigEarlyReturns(t *testing.T) {
 		{
 			name:    "unknown service skips metadata fetch",
 			service: types.StringUnknown(),
+			config:  map[string]interface{}{"schema": "app"},
+		},
+		{
+			name:    "empty service skips metadata fetch",
+			service: types.StringValue(""),
 			config:  map[string]interface{}{"schema": "app"},
 		},
 	}


### PR DESCRIPTION
## Summary

Adds metadata-backed plan-time validation for `fivetran_connection_v2` dynamic `config` and `auth` fields.

## Changes

- Implement `ResourceWithValidateConfig` for `fivetran_connection_v2`.
- Validate dynamic field names, value types, and enum values against connector metadata.
- Warn when metadata returns private preview, development, or sunset fields.
- Fail safely when metadata cannot be fetched, with `skip_plan_time_validation` available as a provider-level escape hatch.
- Add provider setting `skip_plan_time_validation`.
- Add metadata field-status helpers under `framework/core`.
- Add unit coverage for validation, provider schema, metadata failures, empty dynamic objects, and field-status behavior.
