### PR TITLE
`fivetran_connector` config field of strings array is null locally but empty array in upstream. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.36...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.37...HEAD)
+
+## [v1.9.37](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.37...v1.9.36)
+
+### Fixed
+- `fivetran_connector` config field of type of a strings array is null locally, but upstream returned empty array
 
 ## [v1.9.36](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.36...v1.9.35)
 

--- a/fivetran/framework/core/model/connector_config.go
+++ b/fivetran/framework/core/model/connector_config.go
@@ -280,7 +280,7 @@ func getValue(
 			}
 		}
 		if local == nil && currentField != nil && !currentField.Readonly && !isImporting {
-			if len(value.([]interface{})) == 0 {
+			if currentField.GetIsSensitive(service) || len(value.([]interface{})) == 0 {
 				if _, ok := collectionType.(basetypes.SetTypable); ok {
 					return types.SetNull(collectionType.ElementType())
 				} else {

--- a/fivetran/framework/core/model/connector_config.go
+++ b/fivetran/framework/core/model/connector_config.go
@@ -279,6 +279,15 @@ func getValue(
 				return types.ListNull(collectionType.ElementType())
 			}
 		}
+		if local == nil && currentField != nil && !currentField.Readonly && !isImporting {
+			if len(value.([]interface{})) == 0 {
+				if _, ok := collectionType.(basetypes.SetTypable); ok {
+					return types.SetNull(collectionType.ElementType())
+				} else {
+					return types.ListNull(collectionType.ElementType())
+				}
+			}
+		}
 		items := []attr.Value{}
 		for _, v := range value.([]interface{}) {
 			if currentField.ItemKeyField != "" && local != nil {

--- a/fivetran/framework/provider.go
+++ b/fivetran/framework/provider.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const Version = "1.9.36" // Current provider version
+const Version = "1.9.37" // Current provider version
 
 type fivetranProvider struct {
 	mockClient    httputils.HttpClient

--- a/fivetran/framework/resources/connector_test.go
+++ b/fivetran/framework/resources/connector_test.go
@@ -2839,3 +2839,199 @@ func TestResourceConnectorWorkdayServiceMock(t *testing.T) {
 		},
 	)
 }
+
+// TestResourceConnectorConfigArrayOfSensitiveStringsMock verifies that a string array config field
+// if it's null locally doesn't fail on empty array in the upstream API response
+func TestResourceConnectorConfigArrayOfSensitiveStringsMock(t *testing.T) {
+
+	connectorSensitiveArrayStep1Response := `
+	{
+		"id": "connector_id",
+		"group_id": "group_id",
+		"service": "github",
+		"service_version": 1,
+		"schema": "some_schema",
+		"paused": true,
+		"pause_after_trial": true,
+		"connected_by": "user_id",
+		"created_at": "2022-01-01T11:22:33.012345Z",
+		"succeeded_at": null,
+		"failed_at": null,
+		"sync_frequency": 5,
+		"schedule_type": "auto",
+		"networking_method": "Directly",
+		"status": {
+			"setup_state": "incomplete",
+			"sync_state": "paused",
+			"update_state": "on_schedule",
+			"is_historical_sync": true,
+			"tasks": [],
+			"warnings": []
+		},
+		"config": {
+			"auth_mode": "PersonalAccessToken",
+			"pats": ["**********"],
+			"use_webhooks": false
+		}
+	}
+	`
+
+	// pats is now empty array after switching to JWT
+	connectorSensitiveArrayStep2Response := `
+	{
+		"id": "connector_id",
+		"group_id": "group_id",
+		"service": "github",
+		"service_version": 1,
+		"schema": "some_schema",
+		"paused": true,
+		"pause_after_trial": true,
+		"connected_by": "user_id",
+		"created_at": "2022-01-01T11:22:33.012345Z",
+		"succeeded_at": null,
+		"failed_at": null,
+		"sync_frequency": 5,
+		"schedule_type": "auto",
+		"networking_method": "Directly",
+		"status": {
+			"setup_state": "incomplete",
+			"sync_state": "paused",
+			"update_state": "on_schedule",
+			"is_historical_sync": true,
+			"tasks": [],
+			"warnings": []
+		},
+		"config": {
+			"auth_mode": "JWT",
+			"client_id": "client_id1",
+			"private_key": "**********",
+			"pats": [],
+			"use_webhooks": false
+		}
+	}
+	`
+	var (
+	connectorSensitiveArrayMockPostHandler   *mock.Handler
+	connectorSensitiveArrayMockPatchHandler  *mock.Handler
+	connectorSensitiveArrayMockDeleteHandler *mock.Handler
+	connectorSensitiveArrayMockData          map[string]interface{}
+	)
+
+	step1 := resource.TestStep{
+		Config: `
+		resource "fivetran_connector" "test_connector" {
+			provider = fivetran-provider
+
+			group_id = "group_id"
+			service  = "github"
+
+			destination_schema {
+				name = "some_schema"
+			}
+
+			trust_certificates = false
+			trust_fingerprints = false
+			run_setup_tests    = false
+
+			networking_method = "Directly"
+
+			config {
+				auth_mode    = "PersonalAccessToken"
+				pats         = ["pat1"]
+				use_webhooks = "false"
+			}
+		}
+		`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			func(s *terraform.State) error {
+				tfmock.AssertEqual(t, connectorSensitiveArrayMockPostHandler.Interactions, 1)
+				tfmock.AssertNotEmpty(t, connectorSensitiveArrayMockData)
+				return nil
+			},
+			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.auth_mode", "PersonalAccessToken"),
+			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.pats.#", "1"),
+			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.pats.0", "pat1"),
+			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.use_webhooks", "false"),
+		),
+	}
+
+	step2 := resource.TestStep{
+		Config: `
+		resource "fivetran_connector" "test_connector" {
+			provider = fivetran-provider
+
+			group_id = "group_id"
+			service  = "github"
+
+			destination_schema {
+				name = "some_schema"
+			}
+
+			trust_certificates = false
+			trust_fingerprints = false
+			run_setup_tests    = false
+
+			networking_method = "Directly"
+
+			config {
+				auth_mode   = "JWT"
+				client_id   = "client_id1"
+				private_key = "private_key1"
+			}
+		}
+		`,
+		Check: resource.ComposeAggregateTestCheckFunc(
+			func(s *terraform.State) error {
+				tfmock.AssertEqual(t, connectorSensitiveArrayMockPatchHandler.Interactions, 1)
+				return nil
+			},
+			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.auth_mode", "JWT"),
+			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.client_id", "client_id1"),
+			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.private_key", "private_key1"),
+			resource.TestCheckNoResourceAttr("fivetran_connector.test_connector", "config.pats"),
+			resource.TestCheckNoResourceAttr("fivetran_connector.test_connector", "config.pats.#"),
+		),
+	}
+
+	resource.Test(
+		t,
+		resource.TestCase{
+			PreCheck: func() {
+				tfmock.MockClient().Reset()
+				tfmock.MockClient().When(http.MethodGet, "/v1/connections/connector_id").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						return tfmock.FivetranSuccessResponse(t, req, http.StatusOK, "Success", connectorSensitiveArrayMockData), nil
+					},
+				)
+				connectorSensitiveArrayMockPostHandler = tfmock.MockClient().When(http.MethodPost, "/v1/connections").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						connectorSensitiveArrayMockData = tfmock.CreateMapFromJsonString(t, connectorSensitiveArrayStep1Response)
+						return tfmock.FivetranSuccessResponse(t, req, http.StatusCreated, "Success", connectorSensitiveArrayMockData), nil
+					},
+				)
+				connectorSensitiveArrayMockPatchHandler = tfmock.MockClient().When(http.MethodPatch, "/v1/connections/connector_id").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						connectorSensitiveArrayMockData = tfmock.CreateMapFromJsonString(t, connectorSensitiveArrayStep2Response)
+						return tfmock.FivetranSuccessResponse(t, req, http.StatusOK, "Success", connectorSensitiveArrayMockData), nil
+					},
+				)
+				connectorSensitiveArrayMockDeleteHandler = tfmock.MockClient().When(http.MethodDelete, "/v1/connections/connector_id").ThenCall(
+					func(req *http.Request) (*http.Response, error) {
+						connectorSensitiveArrayMockData = nil
+						return tfmock.FivetranSuccessResponse(t, req, http.StatusOK, "Success", connectorSensitiveArrayMockData), nil
+					},
+				)
+			},
+			ProtoV6ProviderFactories: tfmock.ProtoV6ProviderFactories,
+			CheckDestroy: func(s *terraform.State) error {
+				tfmock.AssertEqual(t, connectorSensitiveArrayMockDeleteHandler.Interactions, 1)
+				tfmock.AssertEmpty(t, connectorSensitiveArrayMockData)
+				return nil
+			},
+			Steps: []resource.TestStep{
+				step1,
+				step2,
+			},
+		},
+	)
+}

--- a/fivetran/framework/resources/connector_test.go
+++ b/fivetran/framework/resources/connector_test.go
@@ -2905,7 +2905,7 @@ func TestResourceConnectorConfigArrayOfSensitiveStringsMock(t *testing.T) {
 			"auth_mode": "JWT",
 			"client_id": "client_id1",
 			"private_key": "**********",
-			"pats": [],
+			"pats": ["********"],
 			"use_webhooks": false
 		}
 	}

--- a/fivetran/tests/e2e/resource_connector_e2e_test.go
+++ b/fivetran/tests/e2e/resource_connector_e2e_test.go
@@ -1780,7 +1780,7 @@ func TestResourceConnectorScheduleWithScheduleBlockE2E(t *testing.T) {
 					run_setup_tests = false
 				}
 
-				resource "fivetran_connector_schedule" "this" {
+				resource "fivetran_connector_schedule" "connector_schedule" {
 					provider = fivetran-provider
 
 					connector_id = fivetran_connector.test_connector.id
@@ -1880,9 +1880,9 @@ func TestResourceConnectorScheduleWithScheduleBlockE2E(t *testing.T) {
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "fivetran_log"),
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "fivetran_log_schema"),
 
-					resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "paused", "true"),
-					resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "schedule.schedule_type", "INTERVAL"),
-					resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "schedule.interval", "30"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule", "paused", "true"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule", "schedule.schedule_type", "INTERVAL"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule", "schedule.interval", "30"),
 					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule", "schedule.days_of_week.#", "0"),
 
 					resource.TestCheckResourceAttr("fivetran_connector.test_connector2", "service", "fivetran_log"),

--- a/fivetran/tests/e2e/resource_connector_e2e_test.go
+++ b/fivetran/tests/e2e/resource_connector_e2e_test.go
@@ -1756,160 +1756,262 @@ func TestResourceConnectorScheduleWithScheduleBlockE2E(t *testing.T) {
 					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "schedule.days_of_week.#", "0"),
 				),
 			},
-		// 	{
-		// 		Config: `
-		// 		resource "fivetran_group" "test_group" {
-		// 			provider = fivetran-provider
-		// 			name = "test_group_name"
-		// 		}
+			{
+				Config: `
+				resource "fivetran_group" "test_group" {
+					provider = fivetran-provider
+					name = "test_group_name"
+				}
 
-		// 		resource "fivetran_connector" "test_connector" {
-		// 			provider = fivetran-provider
-		// 			group_id = fivetran_group.test_group.id
-		// 			service = "fivetran_log"
+				resource "fivetran_connector" "test_connector" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "fivetran_log"
 
-		// 			data_delay_sensitivity = "NORMAL"
-		// 			data_delay_threshold = 0
+					data_delay_sensitivity = "NORMAL"
+					data_delay_threshold = 0
 
-		// 			destination_schema {
-		// 				name = "fivetran_log_schema"
-		// 			}
+					destination_schema {
+						name = "fivetran_log_schema"
+					}
 
-		// 			trust_certificates = false
-		// 			trust_fingerprints = false
-		// 			run_setup_tests = false
-		// 		}
+					trust_certificates = false
+					trust_fingerprints = false
+					run_setup_tests = false
+				}
 
-		// 		resource "fivetran_connector_schedule" "this" {
-		// 			provider = fivetran-provider
+				resource "fivetran_connector_schedule" "this" {
+					provider = fivetran-provider
 
-		// 			connector_id = fivetran_connector.test_connector.id
-		// 			paused = "true"
-		// 			schedule {
-		// 				schedule_type = "INTERVAL"
-		// 				interval      = 30
-		// 			}
-		// 		}
+					connector_id = fivetran_connector.test_connector.id
+					paused = "true"
+					schedule {
+						schedule_type = "INTERVAL"
+						interval      = 30
+					}
+				}
 
-		// 		resource "fivetran_connector" "test_connector2" {
-		// 			provider = fivetran-provider
-		// 			group_id = fivetran_group.test_group.id
-		// 			service = "fivetran_log"
+				resource "fivetran_connector" "test_connector2" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "fivetran_log"
 
-		// 			data_delay_sensitivity = "NORMAL"
-		// 			data_delay_threshold = 0
+					data_delay_sensitivity = "NORMAL"
+					data_delay_threshold = 0
 
-		// 			destination_schema {
-		// 				name = "fivetran_log_schema2"
-		// 			}
+					destination_schema {
+						name = "fivetran_log_schema2"
+					}
 
-		// 			trust_certificates = false
-		// 			trust_fingerprints = false
-		// 			run_setup_tests = false
-		// 		}
+					trust_certificates = false
+					trust_fingerprints = false
+					run_setup_tests = false
+				}
 
-		// 		resource "fivetran_connector_schedule" "connector_schedule2" {
-		// 			provider = fivetran-provider
+				resource "fivetran_connector_schedule" "connector_schedule2" {
+					provider = fivetran-provider
 
-		// 			connector_id = fivetran_connector.test_connector2.id
-		// 			paused = "true"
-		// 			schedule {
-		// 				schedule_type = "INTERVAL"
-		// 				interval      = 30
-		// 				days_of_week = ["MONDAY", "TUESDAY"]
-		// 			}
-		// 		}
+					connector_id = fivetran_connector.test_connector2.id
+					paused = "true"
+					schedule {
+						schedule_type = "INTERVAL"
+						interval      = 30
+						days_of_week = ["MONDAY", "TUESDAY"]
+					}
+				}
 
-		// 		resource "fivetran_connector" "test_connector3" {
-		// 			provider = fivetran-provider
-		// 			group_id = fivetran_group.test_group.id
-		// 			service = "fivetran_log"
+				resource "fivetran_connector" "test_connector3" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "fivetran_log"
 
-		// 			data_delay_sensitivity = "NORMAL"
-		// 			data_delay_threshold = 0
+					data_delay_sensitivity = "NORMAL"
+					data_delay_threshold = 0
 
-		// 			destination_schema {
-		// 				name = "fivetran_log_schema3"
-		// 			}
+					destination_schema {
+						name = "fivetran_log_schema3"
+					}
 
-		// 			trust_certificates = false
-		// 			trust_fingerprints = false
-		// 			run_setup_tests = false
-		// 		}
+					trust_certificates = false
+					trust_fingerprints = false
+					run_setup_tests = false
+				}
 
-		// 		resource "fivetran_connector_schedule" "connector_schedule3" {
-		// 			provider = fivetran-provider
+				resource "fivetran_connector_schedule" "connector_schedule3" {
+					provider = fivetran-provider
 
-		// 			connector_id = fivetran_connector.test_connector3.id
-		// 			paused = "true"
-		// 			schedule {
-		// 				schedule_type = "TIME_OF_DAY"
-		// 				time_of_day   = "15:30"
-		// 			}
-		// 		}
+					connector_id = fivetran_connector.test_connector3.id
+					paused = "true"
+					schedule {
+						schedule_type = "TIME_OF_DAY"
+						time_of_day   = "15:30"
+					}
+				}
 
-		// 		resource "fivetran_connector" "test_connector4" {
-		// 			provider = fivetran-provider
-		// 			group_id = fivetran_group.test_group.id
-		// 			service = "fivetran_log"
+				resource "fivetran_connector" "test_connector4" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "fivetran_log"
 
-		// 			data_delay_sensitivity = "NORMAL"
-		// 			data_delay_threshold = 0
+					data_delay_sensitivity = "NORMAL"
+					data_delay_threshold = 0
 
-		// 			destination_schema {
-		// 				name = "fivetran_log_schema4"
-		// 			}
+					destination_schema {
+						name = "fivetran_log_schema4"
+					}
 
-		// 			trust_certificates = false
-		// 			trust_fingerprints = false
-		// 			run_setup_tests = false
-		// 		}
+					trust_certificates = false
+					trust_fingerprints = false
+					run_setup_tests = false
+				}
 
-		// 		resource "fivetran_connector_schedule" "connector_schedule4" {
-		// 			provider = fivetran-provider
+				resource "fivetran_connector_schedule" "connector_schedule4" {
+					provider = fivetran-provider
 
-		// 			connector_id = fivetran_connector.test_connector4.id
-		// 			paused = "true"
-		// 			schedule {
-		// 				schedule_type = "CRON"
-		// 				cron          = "0 15 * * *"
-		// 			}
-		// 		}
-		// 		`,
-		// 		Check: resource.ComposeAggregateTestCheckFunc(
-		// 			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "fivetran_log"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "fivetran_log_schema"),
+					connector_id = fivetran_connector.test_connector4.id
+					paused = "true"
+					schedule {
+						schedule_type = "CRON"
+						cron          = "0 15 * * *"
+					}
+				}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "fivetran_log"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "fivetran_log_schema"),
 
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "paused", "true"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "schedule.schedule_type", "INTERVAL"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "schedule.interval", "30"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule", "schedule.days_of_week.#", "0"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "paused", "true"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "schedule.schedule_type", "INTERVAL"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.this", "schedule.interval", "30"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule", "schedule.days_of_week.#", "0"),
 
-		// 			resource.TestCheckResourceAttr("fivetran_connector.test_connector2", "service", "fivetran_log"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector.test_connector2", "name", "fivetran_log_schema2"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector2", "service", "fivetran_log"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector2", "name", "fivetran_log_schema2"),
 
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule2", "paused", "true"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule2", "schedule.schedule_type", "INTERVAL"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule2", "schedule.interval", "30"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule2", "schedule.days_of_week.#", "2"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule2", "paused", "true"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule2", "schedule.schedule_type", "INTERVAL"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule2", "schedule.interval", "30"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule2", "schedule.days_of_week.#", "2"),
 
-		// 			resource.TestCheckResourceAttr("fivetran_connector.test_connector3", "service", "fivetran_log"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector.test_connector3", "name", "fivetran_log_schema3"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector3", "service", "fivetran_log"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector3", "name", "fivetran_log_schema3"),
 
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule3", "paused", "true"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule3", "schedule.schedule_type", "TIME_OF_DAY"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule3", "schedule.time_of_day", "15:30"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule3", "schedule.days_of_week.#", "0"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule3", "paused", "true"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule3", "schedule.schedule_type", "TIME_OF_DAY"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule3", "schedule.time_of_day", "15:30"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule3", "schedule.days_of_week.#", "0"),
 
-		// 			resource.TestCheckResourceAttr("fivetran_connector.test_connector4", "service", "fivetran_log"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector.test_connector4", "name", "fivetran_log_schema4"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector4", "service", "fivetran_log"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector4", "name", "fivetran_log_schema4"),
 
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "paused", "true"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "schedule.schedule_type", "CRON"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "schedule.cron", "0 15 * * *"),
-		// 			resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "schedule.days_of_week.#", "0"),
-		// 		),
-		// 	},
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "paused", "true"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "schedule.schedule_type", "CRON"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "schedule.cron", "0 15 * * *"),
+					resource.TestCheckResourceAttr("fivetran_connector_schedule.connector_schedule4", "schedule.days_of_week.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceConnectorConfigArrayOfSensitiveStringsE2E(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() {},
+		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+		CheckDestroy:             testFivetranConnectorResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "fivetran_group" "test_group" {
+					provider = fivetran-provider
+					name = "test_group_name"
+			    }
+
+			    resource "fivetran_connector" "test_connector" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "github"
+
+					destination_schema {
+						name = "some_schema"
+					}
+					
+					trust_certificates = false
+					trust_fingerprints = false
+					run_setup_tests = false
+
+					networking_method  = "Directly"
+
+      				config {
+    					auth_mode    = "PersonalAccessToken"
+						pats = ["pat1"]
+						use_webhooks = "false"
+      				}
+				}
+		  `,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("fivetran_group.test_group", "name", "test_group_name"),
+
+					testFivetranConnectorResourceCreate(t, "fivetran_connector.test_connector"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "github"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "some_schema"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "trust_certificates", "false"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "trust_fingerprints", "false"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "run_setup_tests", "false"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "networking_method", "Directly"),
+
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.auth_mode", "PersonalAccessToken"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.pats.#", "1"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.pats.0", "pat1"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.use_webhooks", "false"),
+				),
+			},
+			// Step 2: 
+			{
+				Config: `
+				
+				resource "fivetran_group" "test_group" {
+					provider = fivetran-provider
+					name = "test_group_name"
+			    }
+
+			    resource "fivetran_connector" "test_connector" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "github"
+
+					destination_schema {
+						name = "some_schema"
+					}
+					
+					trust_certificates = false
+					trust_fingerprints = false
+					run_setup_tests = false
+
+					networking_method  = "Directly"
+
+      				config {
+    					auth_mode    = "JWT"
+						client_id    = "client_id1"
+						private_key  = "private_key1"
+      				}
+				}
+		  		`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("fivetran_group.test_group", "name", "test_group_name"),
+
+					testFivetranConnectorResourceCreate(t, "fivetran_connector.test_connector"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "github"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "some_schema"),
+
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.auth_mode", "JWT"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.client_id", "client_id1"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.private_key", "private_key1"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.use_webhooks", "false"),
+					resource.TestCheckNoResourceAttr("fivetran_connector.test_connector", "config.pats"),
+					resource.TestCheckNoResourceAttr("fivetran_connector.test_connector", "config.pats.#"),
+				),
+			},
 		},
 	})
 }

--- a/fivetran/tests/e2e/resource_connector_e2e_test.go
+++ b/fivetran/tests/e2e/resource_connector_e2e_test.go
@@ -1914,7 +1914,7 @@ func TestResourceConnectorScheduleWithScheduleBlockE2E(t *testing.T) {
 	})
 }
 
-func TestResourceConnectorConfigArrayOfSensitiveStringsE2E(t *testing.T) {
+func TestResourceConnectorConfigArrayOfStringsNullLocalyEmptyArrayInUpstreamE2E(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() {},
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories,
@@ -1994,6 +1994,54 @@ func TestResourceConnectorConfigArrayOfSensitiveStringsE2E(t *testing.T) {
     					auth_mode    = "JWT"
 						client_id    = "client_id1"
 						private_key  = "private_key1"
+						pats = []
+						use_webhooks = "false"
+      				}
+				}
+		  		`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("fivetran_group.test_group", "name", "test_group_name"),
+
+					testFivetranConnectorResourceCreate(t, "fivetran_connector.test_connector"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "service", "github"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "name", "some_schema"),
+
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.auth_mode", "JWT"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.client_id", "client_id1"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.private_key", "private_key1"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.use_webhooks", "false"),
+					resource.TestCheckResourceAttr("fivetran_connector.test_connector", "config.pats.#", "0"),
+				),
+			},
+			// Step 3: 
+			{
+				Config: `
+				
+				resource "fivetran_group" "test_group" {
+					provider = fivetran-provider
+					name = "test_group_name"
+			    }
+
+			    resource "fivetran_connector" "test_connector" {
+					provider = fivetran-provider
+					group_id = fivetran_group.test_group.id
+					service = "github"
+
+					destination_schema {
+						name = "some_schema"
+					}
+					
+					trust_certificates = false
+					trust_fingerprints = false
+					run_setup_tests = false
+
+					networking_method  = "Directly"
+
+      				config {
+    					auth_mode    = "JWT"
+						client_id    = "client_id1"
+						private_key  = "private_key1"
+						use_webhooks = "false"
       				}
 				}
 		  		`,


### PR DESCRIPTION
A fix for a case when `fivetran_connector` config field of strings array is null locally but empty array in upstream. Previously produced error as:

> Error: Provider produced inconsistent result after apply
>
> When applying changes to fivetran_connector. , provider
> "provider[\"registry.terraform.io/fivetran/fivetran\"]" produced an unexpected new value: .config-{{}}: inconsistent values ...

