### PR TITLE
Add User-Agent attribution for connection v2 resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `fivetran_connection_v2`: plan-time required-field checks for create and replacement plans, historical resync warnings, and immutable dynamic-field replacement handling.
 - `fivetran_connection_v2_pause_state`: resource implementation for future publication. The resource is not registered yet.
+- `fivetran_connection_v2` and `fivetran_connection_v2_pause_state` requests include their Terraform resource type in the User-Agent for request attribution.
 
 ## [v1.9.37](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.37...v1.9.36)
 

--- a/fivetran/framework/core/metadata_cache.go
+++ b/fivetran/framework/core/metadata_cache.go
@@ -13,6 +13,14 @@ import (
 // The cache is passed explicitly so each provider instance is hermetic (no package-level state).
 // Errors are not cached — transient failures are retried on the next call.
 func GetCachedConnectorMetadata(ctx context.Context, client *fivetran.Client, cache *sync.Map, service string) (*metadata.ConnectorMetadata, error) {
+	return getCachedConnectorMetadata(ctx, client, cache, service, "")
+}
+
+func GetCachedConnectorMetadataWithUserAgentSuffix(ctx context.Context, client *fivetran.Client, cache *sync.Map, service string, userAgentSuffix string) (*metadata.ConnectorMetadata, error) {
+	return getCachedConnectorMetadata(ctx, client, cache, service, userAgentSuffix)
+}
+
+func getCachedConnectorMetadata(ctx context.Context, client *fivetran.Client, cache *sync.Map, service string, userAgentSuffix string) (*metadata.ConnectorMetadata, error) {
 	if cache != nil {
 		if meta, ok, err := LoadCachedConnectorMetadata(cache, service); ok || err != nil {
 			return meta, err
@@ -22,7 +30,16 @@ func GetCachedConnectorMetadata(ctx context.Context, client *fivetran.Client, ca
 		return nil, fmt.Errorf("unconfigured Fivetran client")
 	}
 
-	resp, err := client.NewMetadataDetails().Service(service).Do(ctx)
+	detailsService := client.NewMetadataDetails().Service(service)
+	var (
+		resp metadata.ConnectorMetadataResponse
+		err  error
+	)
+	if userAgentSuffix != "" {
+		resp, err = detailsService.DoWithUserAgentSuffix(ctx, userAgentSuffix)
+	} else {
+		resp, err = detailsService.Do(ctx)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/fivetran/framework/resources/connection_v2.go
+++ b/fivetran/framework/resources/connection_v2.go
@@ -24,6 +24,8 @@ type connectionV2 struct {
 	core.ProviderResource
 }
 
+const connectionV2UserAgentSuffix = "fivetran_connection_v2"
+
 var _ resource.ResourceWithConfigure = &connectionV2{}
 var _ resource.ResourceWithImportState = &connectionV2{}
 var _ resource.ResourceWithModifyPlan = &connectionV2{}
@@ -45,7 +47,7 @@ func (r *connectionV2) ImportState(ctx context.Context, req resource.ImportState
 		return
 	}
 
-	details, err := r.GetClient().NewConnectionDetails().ConnectionID(req.ID).DoCustom(ctx)
+	details, err := r.GetClient().NewConnectionDetails().ConnectionID(req.ID).DoCustomWithUserAgentSuffix(ctx, connectionV2UserAgentSuffix)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Import Connection V2 Resource.",
@@ -133,7 +135,7 @@ func (r *connectionV2) Create(ctx context.Context, req resource.CreateRequest, r
 
 	r.applyCreateRootFields(svc, data)
 
-	response, err := svc.DoCustom(ctx)
+	response, err := svc.DoCustomWithUserAgentSuffix(ctx, connectionV2UserAgentSuffix)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Create Connection V2 Resource.",
@@ -171,7 +173,7 @@ func (r *connectionV2) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	response, err := r.GetClient().NewConnectionDetails().ConnectionID(data.Id.ValueString()).DoCustom(ctx)
+	response, err := r.GetClient().NewConnectionDetails().ConnectionID(data.Id.ValueString()).DoCustomWithUserAgentSuffix(ctx, connectionV2UserAgentSuffix)
 	if err != nil {
 		if response.Code == "NotFound_Connector" || response.Code == "NotFound_Connection" {
 			resp.State.RemoveResource(ctx)
@@ -262,7 +264,7 @@ func (r *connectionV2) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	r.applyUpdateRootFields(svc, plan, state)
 
-	response, err := svc.DoCustom(ctx)
+	response, err := svc.DoCustomWithUserAgentSuffix(ctx, connectionV2UserAgentSuffix)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Update Connection V2 Resource.",
@@ -273,7 +275,7 @@ func (r *connectionV2) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	r.warnFailedSetupTests(response.Data.SetupTests, &resp.Diagnostics)
 
-	details, err := r.GetClient().NewConnectionDetails().ConnectionID(state.Id.ValueString()).DoCustom(ctx)
+	details, err := r.GetClient().NewConnectionDetails().ConnectionID(state.Id.ValueString()).DoCustomWithUserAgentSuffix(ctx, connectionV2UserAgentSuffix)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Read Connection V2 Resource After Update.",
@@ -309,7 +311,7 @@ func (r *connectionV2) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	deleteResponse, err := r.GetClient().NewConnectionDelete().ConnectionID(data.Id.ValueString()).Do(ctx)
+	deleteResponse, err := r.GetClient().NewConnectionDelete().ConnectionID(data.Id.ValueString()).DoWithUserAgentSuffix(ctx, connectionV2UserAgentSuffix)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to Delete Connection V2 Resource.",
@@ -330,7 +332,7 @@ func (r *connectionV2) connectorMetadata(ctx context.Context, service string) (*
 		}
 		return nil, fmt.Errorf("unconfigured Fivetran client")
 	}
-	return core.GetCachedConnectorMetadata(ctx, r.GetClient(), cache, service)
+	return core.GetCachedConnectorMetadataWithUserAgentSuffix(ctx, r.GetClient(), cache, service, connectionV2UserAgentSuffix)
 }
 
 func (r *connectionV2) dynamicPlanMaps(ctx context.Context, data model.ConnectionV2ResourceModel, diags *diag.Diagnostics) (map[string]interface{}, map[string]interface{}) {

--- a/fivetran/framework/resources/connection_v2_pause_state.go
+++ b/fivetran/framework/resources/connection_v2_pause_state.go
@@ -19,6 +19,8 @@ type connectionV2PauseState struct {
 	core.ProviderResource
 }
 
+const connectionV2PauseStateUserAgentSuffix = "fivetran_connection_v2_pause_state"
+
 var _ resource.ResourceWithConfigure = &connectionV2PauseState{}
 var _ resource.ResourceWithImportState = &connectionV2PauseState{}
 
@@ -172,14 +174,14 @@ func (r *connectionV2PauseState) setPauseState(ctx context.Context, connectionID
 		NewConnectionUpdate().
 		ConnectionID(connectionID).
 		Paused(paused).
-		DoCustom(ctx)
+		DoCustomWithUserAgentSuffix(ctx, connectionV2PauseStateUserAgentSuffix)
 }
 
 func (r *connectionV2PauseState) readPauseState(ctx context.Context, connectionID string) (model.ConnectionV2PauseStateResourceModel, connections.DetailsWithCustomConfigNoTestsResponse, error) {
 	response, err := r.GetClient().
 		NewConnectionDetails().
 		ConnectionID(connectionID).
-		DoCustom(ctx)
+		DoCustomWithUserAgentSuffix(ctx, connectionV2PauseStateUserAgentSuffix)
 
 	var data model.ConnectionV2PauseStateResourceModel
 	if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/fivetran/terraform-provider-fivetran
 
 require (
-	github.com/fivetran/go-fivetran v1.3.5
+	github.com/fivetran/go-fivetran v1.3.6
 	github.com/hashicorp/terraform-plugin-framework v1.18.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FM
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/fivetran/go-fivetran v1.3.5 h1:eghEyXFeoR5rD4Vr7+R5aQ04txjy+wGdmyUgnCxoGU8=
-github.com/fivetran/go-fivetran v1.3.5/go.mod h1:EIy5Uwn1zylQCr/7O+8rrwvmjvhW3PPpzHkQj26ON7Y=
+github.com/fivetran/go-fivetran v1.3.6 h1:C49xN6joawM7gUWTREDB/GzsDdQ7EoFvMZOPSkpDwi0=
+github.com/fivetran/go-fivetran v1.3.6/go.mod h1:EIy5Uwn1zylQCr/7O+8rrwvmjvhW3PPpzHkQj26ON7Y=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UNbRM=


### PR DESCRIPTION
## Summary
- Adds request-level User-Agent attribution for `fivetran_connection_v2` and `fivetran_connection_v2_pause_state` API calls.
- Uses the released `go-fivetran v1.3.6` suffix helpers instead of local workspace validation.
- Keeps v2 resources unregistered for future publication.
- Updates the changelog.

## Testing
- GOCACHE=/private/tmp/fivetran-go-cache go test ./fivetran/framework ./fivetran/framework/resources -run 'TestProviderSchemaIncludesSkipPlanTimeValidation|TestConnectionV2|TestConnectionV2PauseState' -count=1
- GOCACHE=/private/tmp/fivetran-go-cache go test ./fivetran/framework/core ./fivetran/framework/resources -run '^$'
- GOCACHE=/private/tmp/fivetran-go-cache go test ./fivetran/framework/datasources ./fivetran/tests/mock -run '^$'
- GOCACHE=/private/tmp/fivetran-go-cache go vet ./fivetran/framework/core ./fivetran/framework
- git diff --check