### PR TITLE
Fix TestResourceConnectorImportingWithTableGroupNameE2E: ignore file_…

### DIFF
--- a/fivetran/tests/e2e/resource_connector_e2e_test.go
+++ b/fivetran/tests/e2e/resource_connector_e2e_test.go
@@ -1111,11 +1111,12 @@ func TestResourceConnectorImportingWithTableGroupNameE2E(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"run_setup_tests", 
-					"trust_certificates", 
+					"run_setup_tests",
+					"trust_certificates",
 					"trust_fingerprints",
 					"data_delay_sensitivity",
 					"auth",
+					"config.file_mapping_method",
 				},
 				ImportStateIdFunc:       func(s *terraform.State) (string, error) {
 					return connectionId, nil


### PR DESCRIPTION
…mapping_method on import

share_point inherits file_mapping_method from FileOAuthCredentials with a default of DEFINE_PER_TABLE. The field is annotated @HiddenField in the backend so it doesn't appear in the OAS spec, but the API always returns it. Import verify fails because the test config doesn't set it.