### PR TITLE
Fix connection_v2 nil-client error in ValidateConfig and ModifyPlan

### DIFF
--- a/fivetran/framework/resources/connection_v2.go
+++ b/fivetran/framework/resources/connection_v2.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -15,6 +16,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// errUnconfiguredClient means metadata is unavailable only because the provider
+// client hasn't been configured yet and nothing was cached. Terraform calls
+// ValidateConfig/ModifyPlan once before Configure (client nil) and again after
+// (client set); callers skip silently on this specific error since the later
+// call with a live client performs the real validation.
+var errUnconfiguredClient = errors.New("unconfigured Fivetran client")
 
 func ConnectionV2() resource.Resource {
 	return &connectionV2{}
@@ -330,7 +338,7 @@ func (r *connectionV2) connectorMetadata(ctx context.Context, service string) (*
 		if meta, ok, err := core.LoadCachedConnectorMetadata(cache, service); ok || err != nil {
 			return meta, err
 		}
-		return nil, fmt.Errorf("unconfigured Fivetran client")
+		return nil, errUnconfiguredClient
 	}
 	return core.GetCachedConnectorMetadataWithUserAgentSuffix(ctx, r.GetClient(), cache, service, connectionV2UserAgentSuffix)
 }

--- a/fivetran/framework/resources/connection_v2_modify_plan.go
+++ b/fivetran/framework/resources/connection_v2_modify_plan.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func (r *connectionV2) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() || r.GetClient() == nil {
+	if req.Plan.Raw.IsNull() {
 		return
 	}
 
@@ -66,6 +67,9 @@ func (r *connectionV2) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 
 	meta, err := r.connectorMetadata(ctx, plan.Service.ValueString())
 	if err != nil {
+		if errors.Is(err, errUnconfiguredClient) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to Modify Connection V2 Plan",
 			fmt.Sprintf("Unable to fetch metadata for service %q. Terraform cannot safely evaluate required or immutable dynamic config/auth fields without metadata. Fix metadata access or set provider skip_plan_time_validation = true to bypass this check temporarily. Original error: %v", plan.Service.ValueString(), err),

--- a/fivetran/framework/resources/connection_v2_modify_plan.go
+++ b/fivetran/framework/resources/connection_v2_modify_plan.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (r *connectionV2) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
-	if req.Plan.Raw.IsNull() {
+	if req.Plan.Raw.IsNull() || r.GetClient() == nil {
 		return
 	}
 

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -17,7 +18,7 @@ import (
 var _ resource.ResourceWithValidateConfig = &connectionV2{}
 
 func (r *connectionV2) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	if r.GetSkipPlanTimeValidation() || r.GetClient() == nil {
+	if r.GetSkipPlanTimeValidation() {
 		return
 	}
 
@@ -41,6 +42,9 @@ func (r *connectionV2) ValidateConfig(ctx context.Context, req resource.Validate
 
 	meta, err := r.connectorMetadata(ctx, data.Service.ValueString())
 	if err != nil {
+		if errors.Is(err, errUnconfiguredClient) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to Validate Connection V2 Configuration",
 			fmt.Sprintf("Unable to fetch metadata for service %q. Terraform cannot safely validate dynamic config/auth fields without metadata. Fix metadata access or set provider skip_plan_time_validation = true to bypass this check temporarily. Original error: %v", data.Service.ValueString(), err),

--- a/fivetran/framework/resources/connection_v2_validate.go
+++ b/fivetran/framework/resources/connection_v2_validate.go
@@ -17,7 +17,7 @@ import (
 var _ resource.ResourceWithValidateConfig = &connectionV2{}
 
 func (r *connectionV2) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	if r.GetSkipPlanTimeValidation() {
+	if r.GetSkipPlanTimeValidation() || r.GetClient() == nil {
 		return
 	}
 

--- a/fivetran/framework/resources/connection_v2_validate_test.go
+++ b/fivetran/framework/resources/connection_v2_validate_test.go
@@ -462,7 +462,7 @@ func TestConnectionV2ValidateConfigSkipsMetadataFetchForEmptyDynamicObjects(t *t
 	}
 }
 
-func TestConnectionV2ValidateConfigReportsUnconfiguredClient(t *testing.T) {
+func TestConnectionV2ValidateConfigSkipsWhenUnconfiguredAndUncached(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -475,8 +475,8 @@ func TestConnectionV2ValidateConfigReportsUnconfiguredClient(t *testing.T) {
 	var resp resource.ValidateConfigResponse
 	r.ValidateConfig(ctx, req, &resp)
 
-	if resp.Diagnostics.ErrorsCount() != 1 {
-		t.Fatalf("errors = %d, want 1: %v", resp.Diagnostics.ErrorsCount(), resp.Diagnostics)
+	if resp.Diagnostics.ErrorsCount() != 0 {
+		t.Fatalf("errors = %d, want 0: %v", resp.Diagnostics.ErrorsCount(), resp.Diagnostics)
 	}
 }
 


### PR DESCRIPTION
When Terraform calls ValidateConfig/ModifyPlan before Configure has run, the provider client is nil and metadata cannot be fetched. Silently skip validation in that case — ModifyPlan runs again after Configure with a live client and performs full validation there.