### PR TITLE
Register fivetran_connection_v2 and fivetran_connection_v2_pause_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.9.39](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.39...v1.9.38)
 
 ### Added
+- `fivetran_connection_v2`: plan-time required-field checks for create and replacement plans, historical resync warnings, and immutable dynamic-field replacement handling.
+- `fivetran_connection_v2_pause_state`: resource implementation for future publication. The resource is not registered yet.
+- `fivetran_connection_v2` and `fivetran_connection_v2_pause_state` requests include their Terraform resource type in the User-Agent for request attribution.
 - `fivetran_connection_v2` and `fivetran_connection_v2_pause_state`: registered internally for alpha testing. Undocumented; not yet announced for general availability.
 
 ## [v1.9.37](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.37...v1.9.36)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.37...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.39...HEAD)
+
+## [v1.9.39](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.39...v1.9.38)
 
 ### Added
-- `fivetran_connection_v2`: plan-time required-field checks for create and replacement plans, historical resync warnings, and immutable dynamic-field replacement handling.
-- `fivetran_connection_v2_pause_state`: resource implementation for future publication. The resource is not registered yet.
-- `fivetran_connection_v2` and `fivetran_connection_v2_pause_state` requests include their Terraform resource type in the User-Agent for request attribution.
+- `fivetran_connection_v2` and `fivetran_connection_v2_pause_state`: registered internally for alpha testing. Undocumented; not yet announced for general availability.
 
 ## [v1.9.37](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.37...v1.9.36)
 

--- a/docs/resources/connection_v2.md
+++ b/docs/resources/connection_v2.md
@@ -8,7 +8,7 @@ page_title: "Resource: fivetran_connection_v2"
 
 Manages a Fivetran connection. Unlike `fivetran_connector`/`fivetran_connection`, `config` and `auth` are provided as dynamic, service-specific objects: their accepted fields, types, and required/readonly/immutable rules are resolved from connector metadata at plan time rather than from a fixed schema. This means the same resource works across services (e.g. `s3`, `postgres`, `fivetran_log`) without a per-service Terraform schema.
 
-Pause state is managed separately via `fivetran_connection_v2_pause_state`; this resource does not expose a `paused` attribute.
+Pause state is managed separately via `fivetran_connection_v2_pause_state`; this resource does not expose a `paused` attribute. **New connections are always created paused.** To start syncing, add a linked `fivetran_connection_v2_pause_state` resource with `paused = false`.
 
 ## Example Usage
 
@@ -20,6 +20,12 @@ resource "fivetran_connection_v2" "connection" {
     config = {
         schema = "my_schema"
     }
+}
+
+# The connection above is created paused. Unpause it to start syncing:
+resource "fivetran_connection_v2_pause_state" "pause_state" {
+    connection_id = fivetran_connection_v2.connection.id
+    paused        = false
 }
 ```
 

--- a/docs/resources/connection_v2.md
+++ b/docs/resources/connection_v2.md
@@ -1,0 +1,60 @@
+---
+page_title: "Resource: fivetran_connection_v2"
+---
+
+# Resource: fivetran_connection_v2
+
+~> **Alpha:** This resource is in alpha and its schema and behavior may change without notice. Not recommended for production use.
+
+Manages a Fivetran connection. Unlike `fivetran_connector`/`fivetran_connection`, `config` and `auth` are provided as dynamic, service-specific objects: their accepted fields, types, and required/readonly/immutable rules are resolved from connector metadata at plan time rather than from a fixed schema. This means the same resource works across services (e.g. `s3`, `postgres`, `fivetran_log`) without a per-service Terraform schema.
+
+Pause state is managed separately via `fivetran_connection_v2_pause_state`; this resource does not expose a `paused` attribute.
+
+## Example Usage
+
+```hcl
+resource "fivetran_connection_v2" "connection" {
+    service  = "fivetran_log"
+    group_id = "group_id"
+
+    config = {
+        schema = "my_schema"
+    }
+}
+```
+
+## Schema
+
+### Required
+
+- `group_id` (String) The unique identifier for the Group (Destination) within the Fivetran system. Changing this forces the connection to be replaced.
+- `service` (String) The connection service type (e.g., `postgres`, `mysql`, `s3`, `snowflake`). Changing this forces the connection to be replaced.
+
+### Optional
+
+- `auth` (Dynamic, Sensitive) Service-specific authorization configuration. The accepted fields are defined by connector metadata at runtime.
+- `config` (Dynamic) Service-specific connection configuration. The accepted fields are defined by connector metadata at runtime.
+- `daily_sync_time` (String) Sync start time. Only used when `sync_frequency` is `1440`.
+- `data_delay_sensitivity` (String) The level of data delay notification threshold. Possible values: `LOW`, `NORMAL`, `HIGH`, `CUSTOM`, `SYNC_FREQUENCY`.
+- `data_delay_threshold` (Number) Custom sync delay notification threshold in minutes. Only used when `data_delay_sensitivity` is `CUSTOM`.
+- `hybrid_deployment_agent_id` (String) The hybrid deployment agent ID for the group the connection belongs to.
+- `networking_method` (String) The networking method for the connection. Possible values: `Directly`, `SshTunnel`, `ProxyAgent`, `PrivateLink`.
+- `pause_after_trial` (Boolean) Whether the connection should be paused after the free trial period has ended.
+- `private_link_id` (String) The private link ID. Required when `networking_method` is `PrivateLink`.
+- `proxy_agent_id` (String) The ID of the proxy agent to use. Required when `networking_method` is `ProxyAgent`.
+- `run_setup_tests` (Boolean) Whether to run setup tests when creating or updating the connection.
+- `schedule_type` (String) The connection schedule configuration type. Supported values: `auto`, `manual`.
+- `sync_frequency` (Number) The connection sync frequency in minutes.
+- `trust_certificates` (Boolean) Whether Fivetran should trust certificates automatically.
+- `trust_fingerprints` (Boolean) Whether Fivetran should trust SSH fingerprints automatically.
+
+### Read-Only
+
+- `connected_by` (String) The unique identifier of the user who created the connection in your account.
+- `created_at` (String) The timestamp of the time the connection was created in your account.
+- `failed_at` (String) The timestamp of the time the connection sync failed last time.
+- `id` (String) The unique identifier for the connection within the Fivetran system.
+- `name` (String) The connection's name.
+- `service_version` (String) The connection type version within the Fivetran system.
+- `status` (Attributes) The current connection status (setup state, sync state, tasks, and warnings).
+- `succeeded_at` (String) The timestamp of the time the connection sync succeeded last time.

--- a/docs/resources/connection_v2_pause_state.md
+++ b/docs/resources/connection_v2_pause_state.md
@@ -1,0 +1,31 @@
+---
+page_title: "Resource: fivetran_connection_v2_pause_state"
+---
+
+# Resource: fivetran_connection_v2_pause_state
+
+~> **Alpha:** This resource is in alpha and its schema and behavior may change without notice. Not recommended for production use.
+
+Manages the paused state of a `fivetran_connection_v2` connection, separately from the connection resource itself. This lets you pause and resume a connection without triggering changes to (or replacement of) the connection's own configuration.
+
+If you are importing both resources, import `fivetran_connection_v2` first, then `fivetran_connection_v2_pause_state` — importing the pause state before the connection exists in state forces a replacement plan.
+
+## Example Usage
+
+```hcl
+resource "fivetran_connection_v2_pause_state" "pause_state" {
+    connection_id = fivetran_connection_v2.connection.id
+    paused        = true
+}
+```
+
+## Schema
+
+### Required
+
+- `connection_id` (String) The unique identifier for the connection whose pause state is managed. Changing this forces the resource to be replaced.
+- `paused` (Boolean) Whether the connection should be paused.
+
+### Read-Only
+
+- `id` (String) The unique identifier for this pause-state resource. This is the connection ID.

--- a/docs/resources/connection_v2_pause_state.md
+++ b/docs/resources/connection_v2_pause_state.md
@@ -8,6 +8,8 @@ page_title: "Resource: fivetran_connection_v2_pause_state"
 
 Manages the paused state of a `fivetran_connection_v2` connection, separately from the connection resource itself. This lets you pause and resume a connection without triggering changes to (or replacement of) the connection's own configuration.
 
+**`fivetran_connection_v2` always creates connections paused.** Add this resource with `paused = false` to start syncing.
+
 If you are importing both resources, import `fivetran_connection_v2` first, then `fivetran_connection_v2_pause_state` — importing the pause state before the connection exists in state forces a replacement plan.
 
 ## Example Usage
@@ -15,7 +17,7 @@ If you are importing both resources, import `fivetran_connection_v2` first, then
 ```hcl
 resource "fivetran_connection_v2_pause_state" "pause_state" {
     connection_id = fivetran_connection_v2.connection.id
-    paused        = true
+    paused        = false
 }
 ```
 

--- a/fivetran/framework/provider.go
+++ b/fivetran/framework/provider.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const Version = "1.9.38" // Current provider version
+const Version = "1.9.39" // Current provider version
 
 type fivetranProvider struct {
 	mockClient    httputils.HttpClient
@@ -144,6 +144,8 @@ func (p *fivetranProvider) Resources(ctx context.Context) []func() resource.Reso
 		resources.TransformationProject,
 		resources.Transformation,
 		resources.ConnectorSdkPackage,
+		resources.ConnectionV2,
+		resources.ConnectionV2PauseState,
 	}
 }
 

--- a/fivetran/framework/resources/connection_v2_test.go
+++ b/fivetran/framework/resources/connection_v2_test.go
@@ -60,18 +60,22 @@ func TestConnectionV2SchemaShape(t *testing.T) {
 	}
 }
 
-func TestConnectionV2NotRegistered(t *testing.T) {
+func TestConnectionV2IsRegistered(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
 	p := framework.FivetranProvider()
+	found := false
 	for _, resourceFactory := range p.Resources(ctx) {
 		r := resourceFactory()
 		var metadataResp resource.MetadataResponse
 		r.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "fivetran"}, &metadataResp)
 		if metadataResp.TypeName == "fivetran_connection_v2" {
-			t.Fatal("fivetran_connection_v2 must remain unregistered until the registration ticket")
+			found = true
 		}
+	}
+	if !found {
+		t.Fatal("fivetran_connection_v2 must be registered")
 	}
 
 	var metadataResp provider.MetadataResponse
@@ -102,18 +106,22 @@ func TestConnectionV2PauseStateSchemaShape(t *testing.T) {
 	assertBoolAttribute(t, attrs, "paused", true, false, false)
 }
 
-func TestConnectionV2PauseStateNotRegistered(t *testing.T) {
+func TestConnectionV2PauseStateIsRegistered(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
 	p := framework.FivetranProvider()
+	found := false
 	for _, resourceFactory := range p.Resources(ctx) {
 		r := resourceFactory()
 		var metadataResp resource.MetadataResponse
 		r.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "fivetran"}, &metadataResp)
 		if metadataResp.TypeName == "fivetran_connection_v2_pause_state" {
-			t.Fatal("fivetran_connection_v2_pause_state must remain unregistered until the publication ticket")
+			found = true
 		}
+	}
+	if !found {
+		t.Fatal("fivetran_connection_v2_pause_state must be registered")
 	}
 }
 


### PR DESCRIPTION
Both resources are alpha and undocumented; not announced for general availability. Update the registration tests to assert presence instead of absence, cut the v1.9.39 changelog entry, and bump the provider version.