### PR TITLE
Make destination_schema_names Required instead of Optional/Computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.40...HEAD)
+## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.41...HEAD)
 
-### Fixed
-- `fivetran_connection_v2`: `destination_schema_names` caused "Provider produced inconsistent result after apply" when omitted from HCL, since the API always returns a value (defaults to `FIVETRAN_NAMING`) but the attribute was not `Computed`.
+## [v1.9.41](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.40...v1.9.41)
+
+### Changed
+- `fivetran_connection_v2`: `destination_schema_names` is now `Required` instead of `Optional`/`Computed`. Users must set it explicitly in HCL.
 
 ## [v1.9.40](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.39...v1.9.40)
 

--- a/docs/resources/connection_v2.md
+++ b/docs/resources/connection_v2.md
@@ -33,6 +33,7 @@ resource "fivetran_connection_v2_pause_state" "pause_state" {
 
 ### Required
 
+- `destination_schema_names` (String) Defines how schema names appear in the destination. Supported values: `FIVETRAN_NAMING`, `SOURCE_NAMING`. Changing this forces the connection to be replaced.
 - `group_id` (String) The unique identifier for the Group (Destination) within the Fivetran system. Changing this forces the connection to be replaced.
 - `service` (String) The connection service type (e.g., `postgres`, `mysql`, `s3`, `snowflake`). Changing this forces the connection to be replaced.
 
@@ -45,7 +46,6 @@ resource "fivetran_connection_v2_pause_state" "pause_state" {
 - `data_delay_sensitivity` (String) The level of data delay notification threshold. Possible values: `LOW`, `NORMAL`, `HIGH`, `CUSTOM`, `SYNC_FREQUENCY`.
 - `data_delay_threshold` (Number) Custom sync delay notification threshold in minutes. Only used when `data_delay_sensitivity` is `CUSTOM`.
 - `destination_configuration` (Attributes) Destination-specific configuration for the connection.
-- `destination_schema_names` (String) Defines how schema names appear in the destination. Supported values: `FIVETRAN_NAMING`, `SOURCE_NAMING`. Changing this forces the connection to be replaced.
 - `hybrid_deployment_agent_id` (String) The hybrid deployment agent ID for the group the connection belongs to.
 - `networking_method` (String) The networking method for the connection. Possible values: `Directly`, `SshTunnel`, `ProxyAgent`, `PrivateLink`.
 - `pause_after_trial` (Boolean) Whether the connection should be paused after the free trial period has ended.

--- a/fivetran/framework/core/schema/connection_v2.go
+++ b/fivetran/framework/core/schema/connection_v2.go
@@ -135,8 +135,7 @@ func ConnectionV2ResourceAttributes() map[string]resourceSchema.Attribute {
 			},
 		},
 		"destination_schema_names": resourceSchema.StringAttribute{
-			Optional:    true,
-			Computed:    true,
+			Required:    true,
 			Description: "Defines how schema names appear in the destination. Supported values: FIVETRAN_NAMING, SOURCE_NAMING.",
 			Validators: []validator.String{
 				stringvalidator.OneOf("FIVETRAN_NAMING", "SOURCE_NAMING"),

--- a/fivetran/framework/provider.go
+++ b/fivetran/framework/provider.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const Version = "1.9.40" // Current provider version
+const Version = "1.9.41" // Current provider version
 
 type fivetranProvider struct {
 	mockClient    httputils.HttpClient

--- a/fivetran/framework/resources/connection_v2_test.go
+++ b/fivetran/framework/resources/connection_v2_test.go
@@ -43,7 +43,7 @@ func TestConnectionV2SchemaShape(t *testing.T) {
 	assertInt64Attribute(t, attrs, "sync_frequency", false, true, true)
 	assertStringAttribute(t, attrs, "schedule_type", false, true, true)
 	assertSingleNestedAttribute(t, attrs, "connect_card_config", false, true, false)
-	assertStringAttribute(t, attrs, "destination_schema_names", false, true, true)
+	assertStringAttribute(t, attrs, "destination_schema_names", true, false, false)
 	assertSingleNestedAttribute(t, attrs, "destination_configuration", false, true, true)
 	assertBoolAttribute(t, attrs, "run_setup_tests", false, true, true)
 	assertBoolAttribute(t, attrs, "trust_certificates", false, true, true)
@@ -64,14 +64,10 @@ func TestConnectionV2SchemaShape(t *testing.T) {
 	}
 }
 
-// TestConnectionV2DestinationSchemaNamesIsComputed guards against a regression
-// where destination_schema_names was Optional but not Computed. The API always
-// returns a value for this field (defaulting to FIVETRAN_NAMING server-side)
-// even when the user omits it from HCL. Without Computed, Terraform's plan
-// value stays null while Create/Read write back the API's real value, and
-// Terraform Core rejects the mismatch with "Provider produced inconsistent
-// result after apply".
-func TestConnectionV2DestinationSchemaNamesIsComputed(t *testing.T) {
+// TestConnectionV2DestinationSchemaNamesIsRequired guards against a regression
+// where destination_schema_names was Optional and Computed. The field is now
+// Required: users must set it explicitly in HCL.
+func TestConnectionV2DestinationSchemaNamesIsRequired(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
@@ -86,11 +82,14 @@ func TestConnectionV2DestinationSchemaNamesIsComputed(t *testing.T) {
 	if !ok {
 		t.Fatalf("destination_schema_names has type %T, want StringAttribute", schemaResp.Schema.Attributes["destination_schema_names"])
 	}
-	if !attr.Computed {
-		t.Fatal("destination_schema_names must be Computed: the API can return a value (e.g. FIVETRAN_NAMING) even when the user never set it, and Terraform requires Computed to allow the plan's null to resolve to that value without an inconsistent-result error")
+	if !attr.Required {
+		t.Fatal("destination_schema_names must be Required")
 	}
-	if !attr.Optional {
-		t.Fatal("destination_schema_names must remain Optional so users can still set it explicitly")
+	if attr.Optional {
+		t.Fatal("destination_schema_names must not be Optional")
+	}
+	if attr.Computed {
+		t.Fatal("destination_schema_names must not be Computed")
 	}
 }
 


### PR DESCRIPTION
Reverts the Computed workaround: users must now set destination_schema_names explicitly in HCL rather than relying on the API's server-side default.