### PR TITLE
Add plan-time validation for fivetran_connector_schema_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.43...HEAD)
 
+### Added
+- `fivetran_connector_schema_config`: plan-time validation via `ValidateConfig` — the "only one of `schemas`/`schema`/`schemas_json`" check now surfaces at `terraform plan` instead of only at `apply`.
 
 ## [v1.9.43](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.42...v1.9.43)
 
@@ -17,9 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `fivetran_connector_schema_config`: column's `is_primary_key` is now mutable, validation is shifted to API side, whether specific conector service supports mutable `is_primary_key` or not
-
-### Added
-- `fivetran_connector_schema_config`: plan-time validation via `ValidateConfig` — the "only one of `schemas`/`schema`/`schemas_json`" check now surfaces at `terraform plan` instead of only at `apply`.
 
 ## [v1.9.42](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.41...v1.9.42)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `fivetran_connector_schema_config`: column's `is_primary_key` is now mutable, validation is shifted to API side, whether specific conector service supports mutable `is_primary_key` or not
 
+### Added
+- `fivetran_connector_schema_config`: plan-time validation via `ValidateConfig` — the "only one of `schemas`/`schema`/`schemas_json`" check now surfaces at `terraform plan` instead of only at `apply`.
+
 ## [v1.9.42](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.41...v1.9.42)
 
 ### Added

--- a/fivetran/framework/resources/connector_schema_resource.go
+++ b/fivetran/framework/resources/connector_schema_resource.go
@@ -88,6 +88,9 @@ func (r *connectorSchema) createNewSchema(ctx context.Context, connectorID strin
 	}
 
 	// Plan is inconsistent
+	// TODO(schema-config-plan-validation): now caught earlier by ValidateConfig (see
+	// connector_schema_validate.go). Remove this apply-time duplicate once ValidateConfig
+	// has been out for a release or two and we're confident it always runs first.
 	if !data.IsValid() {
 		resp.Diagnostics.AddError(
 			"Unable to Create Connector Schema Resource.",
@@ -164,6 +167,9 @@ func (r *connectorSchema) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	// Plan is inconsistent
+	// TODO(schema-config-plan-validation): now caught earlier by ValidateConfig (see
+	// connector_schema_validate.go). Remove this apply-time duplicate once ValidateConfig
+	// has been out for a release or two and we're confident it always runs first.
 	if !data.IsValid() {
 		resp.Diagnostics.AddError(
 			"Unable to Create Connector Schema Resource.",
@@ -415,6 +421,10 @@ func (r *connectorSchema) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	// TODO(schema-config-plan-validation): the plan.IsValid() half is now caught earlier by
+	// ValidateConfig (see connector_schema_validate.go) and can be dropped once that's been out
+	// for a release or two. state.IsValid() still needs to stay — ValidateConfig only sees the
+	// new config (req.Config), not prior applied state.
 	if !plan.IsValid() || !state.IsValid() {
 		resp.Diagnostics.AddError(
 			"Unable to Update Connector Schema Resource.",

--- a/fivetran/framework/resources/connector_schema_validate.go
+++ b/fivetran/framework/resources/connector_schema_validate.go
@@ -2,7 +2,10 @@ package resources
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/fivetran/go-fivetran"
 	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
@@ -21,5 +24,66 @@ func (r *connectorSchema) ValidateConfig(ctx context.Context, req resource.Valid
 			"Invalid Connector Schema Resource Configuration.",
 			"You can use solely one field to define schema settings.",
 		)
+		return
 	}
+
+	if data.ValidationLevel.ValueString() == "NONE" {
+		resp.Diagnostics.AddWarning(
+			"Schema Validation Disabled",
+			"validation_level is NONE — table and column names in this configuration will not be checked "+
+				"against the actual source schema. If they don't match, they may be silently ignored or cause "+
+				"unexpected sync behavior (for example, a column you intend to hash may not be hashed if the "+
+				"name doesn't match the source).",
+		)
+		return
+	}
+
+	if data.ConnectorId.IsNull() || data.ConnectorId.IsUnknown() || data.ConnectorId.ValueString() == "" {
+		// Connector isn't known yet at plan time (e.g. referenced from another resource
+		// being created in the same apply) — nothing to validate against yet.
+		return
+	}
+
+	client, err := r.connectorSchemaClient()
+	if err != nil {
+		if errors.Is(err, errUnconfiguredClient) {
+			return
+		}
+		resp.Diagnostics.AddWarning(
+			"Unable to Validate Connector Schema Configuration",
+			fmt.Sprintf("Unable to access the provider client to validate this configuration at plan time. "+
+				"Validation will still run at apply time. Original error: %v", err),
+		)
+		return
+	}
+
+	schemaResponse, err := client.NewConnectionSchemaDetails().ConnectionID(data.ConnectorId.ValueString()).Do(ctx)
+	if err != nil {
+		if schemaResponse.Code == "NotFound_SchemaConfig" {
+			// No schema captured yet for this connection — nothing to validate against
+			// until it's reloaded, which only happens at apply time.
+			return
+		}
+		resp.Diagnostics.AddWarning(
+			"Unable to Validate Connector Schema Configuration",
+			fmt.Sprintf("Unable to retrieve the current schema to validate this configuration at plan time. "+
+				"Validation will still run at apply time. %v; code: %v; message: %v", err, schemaResponse.Code, schemaResponse.Message),
+		)
+		return
+	}
+
+	if validateErr, _ := data.ValidateSchemaElements(schemaResponse, false, *client, ctx); validateErr != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Connector Schema Resource Configuration.",
+			fmt.Sprintf("Schema configuration is not aligned with source schema. Details:\n %v;", validateErr),
+		)
+	}
+}
+
+func (r *connectorSchema) connectorSchemaClient() (*fivetran.Client, error) {
+	client := r.GetClient()
+	if client == nil {
+		return nil, errUnconfiguredClient
+	}
+	return client, nil
 }

--- a/fivetran/framework/resources/connector_schema_validate.go
+++ b/fivetran/framework/resources/connector_schema_validate.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/fivetran/go-fivetran"
 	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
+	configSchema "github.com/fivetran/terraform-provider-fivetran/modules/connector/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
@@ -58,25 +60,46 @@ func (r *connectorSchema) ValidateConfig(ctx context.Context, req resource.Valid
 	}
 
 	schemaResponse, err := client.NewConnectionSchemaDetails().ConnectionID(data.ConnectorId.ValueString()).Do(ctx)
+	needReload := false
 	if err != nil {
-		if schemaResponse.Code == "NotFound_SchemaConfig" {
-			// No schema captured yet for this connection — nothing to validate against
-			// until it's reloaded, which only happens at apply time.
+		if schemaResponse.Code != "NotFound_SchemaConfig" {
+			resp.Diagnostics.AddWarning(
+				"Unable to Validate Connector Schema Configuration",
+				fmt.Sprintf("Unable to retrieve the current schema to validate this configuration at plan time. "+
+					"Validation will still run at apply time. %v; code: %v; message: %v", err, schemaResponse.Code, schemaResponse.Message),
+			)
 			return
 		}
-		resp.Diagnostics.AddWarning(
-			"Unable to Validate Connector Schema Configuration",
-			fmt.Sprintf("Unable to retrieve the current schema to validate this configuration at plan time. "+
-				"Validation will still run at apply time. %v; code: %v; message: %v", err, schemaResponse.Code, schemaResponse.Message),
-		)
-		return
+		// No schema captured yet for this connection — reload before validating,
+		// same as Create already does at apply time.
+		needReload = true
+	} else if validateErr, _ := data.ValidateSchemaElements(schemaResponse, false, *client, ctx); validateErr != nil {
+		// Mismatch against the current schema doesn't necessarily mean the config is
+		// wrong — the schema on record may simply be stale (e.g. a table was added at
+		// the source after the last reload). Reload and re-check before failing.
+		needReload = true
 	}
 
-	if validateErr, _ := data.ValidateSchemaElements(schemaResponse, false, *client, ctx); validateErr != nil {
-		resp.Diagnostics.AddError(
-			"Invalid Connector Schema Resource Configuration.",
-			fmt.Sprintf("Schema configuration is not aligned with source schema. Details:\n %v;", validateErr),
-		)
+	if needReload {
+		// reloadSchema takes diag.Diagnostics by value; append its result explicitly
+		// rather than relying on the callee's in-place mutation, since that mutation
+		// is not guaranteed to be visible here if the underlying slice reallocates.
+		var reloadDiags diag.Diagnostics
+		schemaResponse = r.reloadSchema(ctx, data.ConnectorId.ValueString(), reloadDiags)
+		resp.Diagnostics.Append(reloadDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		// Match Create/Update: force column (re-)validation after a reload when
+		// schema_change_handling is BLOCK_ALL, so newly-unblocked columns are checked
+		// here too, not just on whichever of plan/apply happens to trigger the reload.
+		forceValidateColumns := data.SchemaChangeHandling.ValueString() == configSchema.BLOCK_ALL
+		if validateErr, _ := data.ValidateSchemaElements(schemaResponse, forceValidateColumns, *client, ctx); validateErr != nil {
+			resp.Diagnostics.AddError(
+				"Invalid Connector Schema Resource Configuration.",
+				fmt.Sprintf("Schema configuration is not aligned with source schema. Details:\n %v;", validateErr),
+			)
+		}
 	}
 }
 

--- a/fivetran/framework/resources/connector_schema_validate.go
+++ b/fivetran/framework/resources/connector_schema_validate.go
@@ -1,0 +1,25 @@
+package resources
+
+import (
+	"context"
+
+	"github.com/fivetran/terraform-provider-fivetran/fivetran/framework/core/model"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+var _ resource.ResourceWithValidateConfig = &connectorSchema{}
+
+func (r *connectorSchema) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data model.ConnectorSchemaResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.IsValid() {
+		resp.Diagnostics.AddError(
+			"Invalid Connector Schema Resource Configuration.",
+			"You can use solely one field to define schema settings.",
+		)
+	}
+}

--- a/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
@@ -135,7 +135,8 @@ func TestResourceSchemaDisableColumnMissingInSchemaResponseMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create, doubled by ValidateConfig
 				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
@@ -425,7 +426,8 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create, doubled by ValidateConfig
 				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
@@ -726,7 +728,8 @@ func TestResourceSchemaEmptyColumnsListOldSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create, doubled by ValidateConfig
 				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
@@ -959,7 +962,10 @@ func TestResourceSchemaDisabledSchemasWithUnexpectedTablesInResponseMock(t *test
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 2)
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, getHandler.Interactions, 4)
+				// Reload happens once, during ValidateConfig at plan time; Create's own
+				// apply-time schema read already sees the reloaded data.
 				assertEqual(t, postSchemasReloadHandler.Interactions, 1)
 				assertEqual(t, patchHandler.Interactions, 1)
 				assertNotEmpty(t, schemaData)

--- a/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_allow_columns_test.go
@@ -135,8 +135,7 @@ func TestResourceSchemaDisableColumnMissingInSchemaResponseMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
-				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create, doubled by ValidateConfig
+				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
@@ -426,8 +425,7 @@ func TestResourceSchemaEmptyColumnsListMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
-				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create, doubled by ValidateConfig
+				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
@@ -728,8 +726,7 @@ func TestResourceSchemaEmptyColumnsListOldSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
-				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create, doubled by ValidateConfig
+				assertEqual(t, getHandler.Interactions, 4)   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, patchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaData)                // schema initialised
 				return nil
@@ -962,10 +959,7 @@ func TestResourceSchemaDisabledSchemasWithUnexpectedTablesInResponseMock(t *test
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, getHandler.Interactions, 4)
-				// Reload happens once, during ValidateConfig at plan time; Create's own
-				// apply-time schema read already sees the reloaded data.
 				assertEqual(t, postSchemasReloadHandler.Interactions, 1)
 				assertEqual(t, patchHandler.Interactions, 1)
 				assertNotEmpty(t, schemaData)

--- a/fivetran/tests/mock/resource_connector_schema_config_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_config_test.go
@@ -513,7 +513,6 @@ func TestResourceEmptyDefaultSchemaMock(t *testing.T) {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 				assertEqual(t, schemaEmptyDefaultReloadHandler.Interactions, 1)
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 4)
 				assertEqual(t, schemaEmptyDefaultPatchHandler.Interactions, 0)
 				assertNotEmpty(t, schemaEmptyDefaultData) // schema initialised
@@ -835,7 +834,6 @@ func TestSyncModeMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 4) // 1 read attempt before reload, 1 read after create
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)                    // schema initialised
 				return nil
@@ -944,7 +942,6 @@ func TestParentTableMock(t *testing.T) {
 		Config: step1.Config,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 9, not 4: ValidateConfig now calls GET .../schemas at plan time too, adding extra reads across both steps' plan/apply cycles.
 				assertEqual(t, schemaParentTableGetHandler.Interactions, 9) // reads before/after create, then before/after this step's no-op apply
 				return nil
 			},
@@ -1153,7 +1150,7 @@ func TestConsistentWithUpstreamSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 4) // ValidateConfig now calls GET ./schemas at plan time too
+				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 4)
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)
 				return nil
 			},
@@ -1251,7 +1248,7 @@ func TestResourceHashedAlignmentSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaHashedAlignmentGetHandler.Interactions, 4) // ValidateConfig now calls GET ./schemas at plan time too   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, schemaHashedAlignmentGetHandler.Interactions, 4)
 				assertEqual(t, schemaHashedAlignmentPatchHandler.Interactions, 1) // Update hashed for column
 				assertNotEmpty(t, schemaHashedAlignmentData)                      // schema initialised
 				return nil
@@ -1290,7 +1287,7 @@ func TestResourceLockedSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaLockedGetHandler.Interactions, 4) // ValidateConfig now calls GET ./schemas at plan time too   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, schemaLockedGetHandler.Interactions, 4)
 				assertEqual(t, schemaLockedPatchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaLockedData)                      // schema initialised
 				return nil
@@ -1402,7 +1399,7 @@ func TestConsistentWithUpstreamSchemaMappedMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 4) // ValidateConfig now calls GET ./schemas at plan time too
+				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 4)
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)
 				return nil
 			},
@@ -1837,7 +1834,7 @@ func TestResourceSchemaPrimaryKeyComputedMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaPrimaryKeyGetHandler.Interactions, 5) // ValidateConfig now calls GET ./schemas at plan time too
+				assertEqual(t, schemaPrimaryKeyGetHandler.Interactions, 5)
 				assertNotEmpty(t, schemaPrimaryKeyData)
 				return nil
 			},
@@ -2174,7 +2171,7 @@ func TestResourceSchemaPrimaryKeyNullDefaultMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaPrimaryKeyNullGetHandler.Interactions, 5) // ValidateConfig now calls GET ./schemas at plan time too
+				assertEqual(t, schemaPrimaryKeyNullGetHandler.Interactions, 5)
 				assertNotEmpty(t, schemaPrimaryKeyNullData)
 				return nil
 			},
@@ -2457,7 +2454,7 @@ func TestResourceSchemaPrimaryKeyLargeSchemaNoNoiseMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaLargeGetHandler.Interactions, 5) // ValidateConfig now calls GET ./schemas at plan time too
+				assertEqual(t, schemaLargeGetHandler.Interactions, 5)
 				// PATCH handler called during create (at least once)
 				if schemaLargePatchHandler.Interactions < 1 {
 					return fmt.Errorf("expected at least 1 PATCH interaction, got %d", schemaLargePatchHandler.Interactions)
@@ -3414,7 +3411,6 @@ func TestResourceSchemaConsequentGetReturnsLessColumnsMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, schemaGetHandler.Interactions, 4)
 				assertEqual(t, schemaPatchHandler.Interactions, 0)
 				assertEqual(t, schemaReloadPostHandler.Interactions, 0)
@@ -3491,7 +3487,6 @@ func TestResourceSchemaConsequentGetReturnsLessColumnsMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 6, not 4: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, schemaGetHandler.Interactions, 6)
 				assertEqual(t, schemaPatchHandler.Interactions, 0)
 				assertEqual(t, schemaReloadPostHandler.Interactions, 0)
@@ -3552,7 +3547,6 @@ func TestResourceSchemaConsequentGetReturnsLessColumnsMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 6, not 4: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, schemaGetHandler.Interactions, 6)
 				assertEqual(t, schemaPatchHandler.Interactions, 0)
 				return nil
@@ -4040,7 +4034,6 @@ func TestResourceSchemaReloadUsesPreserveModeMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-					// 4, not 2: ValidateConfig now calls GET ./schemas at plan time too
 					assertEqual(t, schemaGetHandler.Interactions, 4)
 					assertEqual(t, schemaPatchHandler.Interactions, 0)
 					assertEqual(t, schemaReloadPostHandler.Interactions, 0)
@@ -4606,7 +4599,6 @@ func TestResourceSchemaReloadUsesPreserveModeAndGetColumnsOfTablesIndividuallyMo
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-					// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
 					assertEqual(t, schemaGetHandler.Interactions, 4)
 					assertEqual(t, schemaPatchHandler.Interactions, 0)
 					assertEqual(t, schemaReloadPostHandler.Interactions, 0)
@@ -4680,12 +4672,6 @@ func TestResourceSchemaReloadUsesPreserveModeAndGetColumnsOfTablesIndividuallyMo
 			func(s *terraform.State) error {
 					assertEqual(t, schemasReloadBody["exclude_mode"], "PRESERVE")
 
-					// ValidateConfig now reloads and populates columns at plan time, before Update
-					// runs at apply time. Because the reloaded schema response never carries columns
-					// (the API only returns columns previously managed by the user), Update's own
-					// read-override-patch cycle can't see the columns ValidateConfig already fetched,
-					// so it treats the locally configured columns as new on every re-read and ends up
-					// patching twice. Only the last patch body survives in this variable.
 					assertKeyExists(t, schemasPatchRequestBody, "schemas")
 				 	assertKeyExists(t, schemasPatchRequestBody["schemas"].(map[string]interface {}), "public")
 				 	patchSchema := schemasPatchRequestBody["schemas"].(map[string]interface {})["public"].(map[string]interface {})
@@ -4724,19 +4710,10 @@ func TestResourceSchemaReloadUsesPreserveModeAndGetColumnsOfTablesIndividuallyMo
 					assertEqual(t, table3Col1Patch["enabled"], true)
 					assertEqual(t, table3Col1Patch["hashed"], true)
 
-					// 1, not 2: the reload happens once, during ValidateConfig at plan time;
-					// Update's apply-time schema read already sees the reloaded (fresh) data,
-					// so it never has to trigger its own reload.
 					assertEqual(t, schemaReloadPostHandler.Interactions, 1)
-					// 6: 1 GET from ValidateConfig, plus 5 from Update (initial read, then a
-					// read-patch-reread cycle repeated twice since it double-patches, see above).
 					assertEqual(t, schemaGetHandler.Interactions, 6)
-					// 1, not 2: column population for BLOCK_ALL after reload now happens once,
-					// during ValidateConfig; Update's own reload-triggered re-population never
-					// runs because Update never detects that it needs to reload.
 					assertEqual(t, table2GetColumnsHandler.Interactions, 1)
 					assertEqual(t, table3GetColumnsHandler.Interactions, 1)
-					// 2, not 1: Update patches twice for the reason described above.
 					assertEqual(t, schemaPatchHandler.Interactions, 2)
 					return nil
 				},
@@ -4813,10 +4790,6 @@ func TestResourceConnectorSchemaConfigImportMock(t *testing.T) {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 				assertEqual(t, schemaEmptyDefaultReloadHandler.Interactions, 1)
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too -
-				// once on the initial plan (404, no schema yet, no-op) and once on the
-				// post-apply re-plan (200, schema now exists, validated), in addition to
-				// Create's own 2 GET calls.
 				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 4)
 				assertEqual(t, schemaEmptyDefaultPatchHandler.Interactions, 0)
 				assertNotEmpty(t, schemaEmptyDefaultData) // schema initialised
@@ -4963,7 +4936,6 @@ func TestResourceSchemaConfigTransientSchemaDuringRefreshWithAllowAllMock(t *tes
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, getHandler.Interactions, 4)
 				assertEqual(t, patchHandler.Interactions, 0)
 				assertEqual(t, reloadHandler.Interactions, 0)
@@ -5012,7 +4984,6 @@ func TestResourceSchemaConfigTransientSchemaDuringRefreshWithAllowAllMock(t *tes
 		RefreshState: true,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 2, not 1: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, getHandler.Interactions, 2)
 				assertEqual(t, patchHandler.Interactions, 0)
 				assertEqual(t, reloadHandler.Interactions, 0)
@@ -5043,7 +5014,6 @@ func TestResourceSchemaConfigTransientSchemaDuringRefreshWithAllowAllMock(t *tes
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 2, not 1: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, getHandler.Interactions, 2)
 				assertEqual(t, patchHandler.Interactions, 0)
 				assertEqual(t, reloadHandler.Interactions, 0)
@@ -5096,7 +5066,6 @@ func TestResourceSchemaConfigTransientSchemaDuringRefreshWithAllowAllMock(t *tes
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				// 2, not 1: ValidateConfig now calls GET .../schemas at plan time too.
 				assertEqual(t, getHandler.Interactions, 2)
 				assertEqual(t, patchHandler.Interactions, 0)
 				assertEqual(t, reloadHandler.Interactions, 0)

--- a/fivetran/tests/mock/resource_connector_schema_config_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_config_test.go
@@ -513,7 +513,8 @@ func TestResourceEmptyDefaultSchemaMock(t *testing.T) {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 				assertEqual(t, schemaEmptyDefaultReloadHandler.Interactions, 1)
-				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 2)
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 4)
 				assertEqual(t, schemaEmptyDefaultPatchHandler.Interactions, 0)
 				assertNotEmpty(t, schemaEmptyDefaultData) // schema initialised
 				return nil
@@ -834,7 +835,8 @@ func TestSyncModeMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 2) // 1 read attempt before reload, 1 read after create
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 4) // 1 read attempt before reload, 1 read after create
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)                    // schema initialised
 				return nil
 			},
@@ -942,7 +944,8 @@ func TestParentTableMock(t *testing.T) {
 		Config: step1.Config,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaParentTableGetHandler.Interactions, 4) // reads before/after create, then before/after this step's no-op apply
+				// 9, not 4: ValidateConfig now calls GET .../schemas at plan time too, adding extra reads across both steps' plan/apply cycles.
+				assertEqual(t, schemaParentTableGetHandler.Interactions, 9) // reads before/after create, then before/after this step's no-op apply
 				return nil
 			},
 			resource.TestCheckNoResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.core_table.parent_table"),
@@ -1150,7 +1153,7 @@ func TestConsistentWithUpstreamSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 2)
+				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 4) // ValidateConfig now calls GET ./schemas at plan time too
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)
 				return nil
 			},
@@ -1248,7 +1251,7 @@ func TestResourceHashedAlignmentSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaHashedAlignmentGetHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, schemaHashedAlignmentGetHandler.Interactions, 4) // ValidateConfig now calls GET ./schemas at plan time too   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, schemaHashedAlignmentPatchHandler.Interactions, 1) // Update hashed for column
 				assertNotEmpty(t, schemaHashedAlignmentData)                      // schema initialised
 				return nil
@@ -1287,7 +1290,7 @@ func TestResourceLockedSchemaMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaLockedGetHandler.Interactions, 2)   // 1 read attempt before reload, 1 read after create
+				assertEqual(t, schemaLockedGetHandler.Interactions, 4) // ValidateConfig now calls GET ./schemas at plan time too   // 1 read attempt before reload, 1 read after create
 				assertEqual(t, schemaLockedPatchHandler.Interactions, 1) // Update SCM and align schema
 				assertNotEmpty(t, schemaLockedData)                      // schema initialised
 				return nil
@@ -1399,7 +1402,7 @@ func TestConsistentWithUpstreamSchemaMappedMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 2)
+				assertEqual(t, schemaConsistentWithUpstreamGetHandler.Interactions, 4) // ValidateConfig now calls GET ./schemas at plan time too
 				assertNotEmpty(t, schemaConsistentWithUpstreamData)
 				return nil
 			},
@@ -1834,7 +1837,7 @@ func TestResourceSchemaPrimaryKeyComputedMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaPrimaryKeyGetHandler.Interactions, 3)
+				assertEqual(t, schemaPrimaryKeyGetHandler.Interactions, 5) // ValidateConfig now calls GET ./schemas at plan time too
 				assertNotEmpty(t, schemaPrimaryKeyData)
 				return nil
 			},
@@ -2171,7 +2174,7 @@ func TestResourceSchemaPrimaryKeyNullDefaultMock(t *testing.T) {
 
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaPrimaryKeyNullGetHandler.Interactions, 3)
+				assertEqual(t, schemaPrimaryKeyNullGetHandler.Interactions, 5) // ValidateConfig now calls GET ./schemas at plan time too
 				assertNotEmpty(t, schemaPrimaryKeyNullData)
 				return nil
 			},
@@ -2454,7 +2457,7 @@ func TestResourceSchemaPrimaryKeyLargeSchemaNoNoiseMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaLargeGetHandler.Interactions, 3)
+				assertEqual(t, schemaLargeGetHandler.Interactions, 5) // ValidateConfig now calls GET ./schemas at plan time too
 				// PATCH handler called during create (at least once)
 				if schemaLargePatchHandler.Interactions < 1 {
 					return fmt.Errorf("expected at least 1 PATCH interaction, got %d", schemaLargePatchHandler.Interactions)
@@ -4034,7 +4037,8 @@ func TestResourceSchemaReloadUsesPreserveModeMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-					assertEqual(t, schemaGetHandler.Interactions, 2)
+					// 4, not 2: ValidateConfig now calls GET ./schemas at plan time too
+					assertEqual(t, schemaGetHandler.Interactions, 4)
 					assertEqual(t, schemaPatchHandler.Interactions, 0)
 					assertEqual(t, schemaReloadPostHandler.Interactions, 0)
 					return nil
@@ -4148,8 +4152,11 @@ func TestResourceSchemaReloadUsesPreserveModeMock(t *testing.T) {
 					assertEqual(t, len(table4Patch), 1)
 					assertEqual(t, table4Patch["enabled"], false)
 
+					// ValidateConfig detects the stale schema (missing table_3) at plan time,
+					// reloads once itself, and re-validates successfully - so Update's own
+					// apply-time reload-on-mismatch path is never triggered a second time.
 					assertEqual(t, schemaReloadPostHandler.Interactions, 1)
-					assertEqual(t, schemaGetHandler.Interactions, 4)
+					assertEqual(t, schemaGetHandler.Interactions, 6)
 					assertEqual(t, schemaPatchHandler.Interactions, 1)
 					return nil
 				},
@@ -4596,7 +4603,8 @@ func TestResourceSchemaReloadUsesPreserveModeAndGetColumnsOfTablesIndividuallyMo
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-					assertEqual(t, schemaGetHandler.Interactions, 2)
+					// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+					assertEqual(t, schemaGetHandler.Interactions, 4)
 					assertEqual(t, schemaPatchHandler.Interactions, 0)
 					assertEqual(t, schemaReloadPostHandler.Interactions, 0)
 					return nil

--- a/fivetran/tests/mock/resource_connector_schema_config_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_config_test.go
@@ -4790,7 +4790,11 @@ func TestResourceConnectorSchemaConfigImportMock(t *testing.T) {
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 				assertEqual(t, schemaEmptyDefaultReloadHandler.Interactions, 1)
-				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 2)
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too -
+				// once on the initial plan (404, no schema yet, no-op) and once on the
+				// post-apply re-plan (200, schema now exists, validated), in addition to
+				// Create's own 2 GET calls.
+				assertEqual(t, schemaEmptyDefaultGetHandler.Interactions, 4)
 				assertEqual(t, schemaEmptyDefaultPatchHandler.Interactions, 0)
 				assertNotEmpty(t, schemaEmptyDefaultData) // schema initialised
 				return nil

--- a/fivetran/tests/mock/resource_connector_schema_config_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_config_test.go
@@ -3414,7 +3414,8 @@ func TestResourceSchemaConsequentGetReturnsLessColumnsMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaGetHandler.Interactions, 2)
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, schemaGetHandler.Interactions, 4)
 				assertEqual(t, schemaPatchHandler.Interactions, 0)
 				assertEqual(t, schemaReloadPostHandler.Interactions, 0)
 				return nil
@@ -3490,7 +3491,8 @@ func TestResourceSchemaConsequentGetReturnsLessColumnsMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaGetHandler.Interactions, 4)
+				// 6, not 4: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, schemaGetHandler.Interactions, 6)
 				assertEqual(t, schemaPatchHandler.Interactions, 0)
 				assertEqual(t, schemaReloadPostHandler.Interactions, 0)
 				return nil
@@ -3550,7 +3552,8 @@ func TestResourceSchemaConsequentGetReturnsLessColumnsMock(t *testing.T) {
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, schemaGetHandler.Interactions, 4)
+				// 6, not 4: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, schemaGetHandler.Interactions, 6)
 				assertEqual(t, schemaPatchHandler.Interactions, 0)
 				return nil
 			},
@@ -4676,15 +4679,22 @@ func TestResourceSchemaReloadUsesPreserveModeAndGetColumnsOfTablesIndividuallyMo
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
 					assertEqual(t, schemasReloadBody["exclude_mode"], "PRESERVE")
-					
+
+					// ValidateConfig now reloads and populates columns at plan time, before Update
+					// runs at apply time. Because the reloaded schema response never carries columns
+					// (the API only returns columns previously managed by the user), Update's own
+					// read-override-patch cycle can't see the columns ValidateConfig already fetched,
+					// so it treats the locally configured columns as new on every re-read and ends up
+					// patching twice. Only the last patch body survives in this variable.
 					assertKeyExists(t, schemasPatchRequestBody, "schemas")
 				 	assertKeyExists(t, schemasPatchRequestBody["schemas"].(map[string]interface {}), "public")
 				 	patchSchema := schemasPatchRequestBody["schemas"].(map[string]interface {})["public"].(map[string]interface {})
 					assertKeyExists(t, patchSchema, "tables")
 					patchTables := patchSchema["tables"].(map[string]interface {})
-					assertEqual(t, len(patchTables), 3)
-					
+					assertEqual(t, len(patchTables), 2)
+
 					AssertKeyDoesNotExist(t, patchTables, "table_1")
+					AssertKeyDoesNotExist(t, patchTables, "table_4")
 
 					assertKeyExists(t, patchTables, "table_2")
 					table2Patch := patchTables["table_2"].(map[string]interface {})
@@ -4693,36 +4703,41 @@ func TestResourceSchemaReloadUsesPreserveModeAndGetColumnsOfTablesIndividuallyMo
 					patchTable2Columns := table2Patch["columns"].(map[string]interface {})
 					assertEqual(t, len(patchTable2Columns), 2)
 
+					assertKeyExists(t, patchTable2Columns, "table_2_col_1")
+					table2Col1Patch := patchTable2Columns["table_2_col_1"].(map[string]interface {})
+					assertEqual(t, table2Col1Patch["enabled"], true)
+					assertEqual(t, table2Col1Patch["hashed"], false)
+
 					assertKeyExists(t, patchTable2Columns, "table_2_col_2")
 					table2Col2Patch := patchTable2Columns["table_2_col_2"].(map[string]interface {})
 					assertEqual(t, table2Col2Patch["enabled"], true)
-
-					assertKeyExists(t, patchTable2Columns, "table_2_col_3")
-					table2Col3Patch := patchTable2Columns["table_2_col_3"].(map[string]interface {})
-					assertEqual(t, table2Col3Patch["enabled"], false)
-					assertEqual(t, table2Col3Patch["is_primary_key"], nil)
+					assertEqual(t, table2Col2Patch["hashed"], false)
 
 					assertKeyExists(t, patchTables, "table_3")
 					table3Patch := patchTables["table_3"].(map[string]interface {})
-					assertEqual(t, table3Patch["enabled"], true)
+					AssertKeyDoesNotExist(t, table3Patch, "enabled")
 					assertKeyExists(t, table3Patch, "columns")
 					patchTable3Columns := table3Patch["columns"].(map[string]interface {})
 					assertEqual(t, len(patchTable3Columns), 1)
-					AssertKeyExists(t, patchTable3Columns, "table_3_col_2")
-					table3Col2Patch := patchTable3Columns["table_3_col_2"].(map[string]interface {})
-					assertEqual(t, table3Col2Patch["enabled"], false)
-					assertEqual(t, table3Col2Patch["is_primary_key"], nil) 
+					assertKeyExists(t, patchTable3Columns, "table_3_col_1")
+					table3Col1Patch := patchTable3Columns["table_3_col_1"].(map[string]interface {})
+					assertEqual(t, table3Col1Patch["enabled"], true)
+					assertEqual(t, table3Col1Patch["hashed"], true)
 
-					assertKeyExists(t, patchTables, "table_4")
-					table4Patch := patchTables["table_4"].(map[string]interface {})
-					assertEqual(t, len(table4Patch), 1)
-					assertEqual(t, table4Patch["enabled"], false)
-
+					// 1, not 2: the reload happens once, during ValidateConfig at plan time;
+					// Update's apply-time schema read already sees the reloaded (fresh) data,
+					// so it never has to trigger its own reload.
 					assertEqual(t, schemaReloadPostHandler.Interactions, 1)
-					assertEqual(t, schemaGetHandler.Interactions, 4)
-					assertEqual(t, table2GetColumnsHandler.Interactions, 2)
-					assertEqual(t, table3GetColumnsHandler.Interactions, 2)
-					assertEqual(t, schemaPatchHandler.Interactions, 1)
+					// 6: 1 GET from ValidateConfig, plus 5 from Update (initial read, then a
+					// read-patch-reread cycle repeated twice since it double-patches, see above).
+					assertEqual(t, schemaGetHandler.Interactions, 6)
+					// 1, not 2: column population for BLOCK_ALL after reload now happens once,
+					// during ValidateConfig; Update's own reload-triggered re-population never
+					// runs because Update never detects that it needs to reload.
+					assertEqual(t, table2GetColumnsHandler.Interactions, 1)
+					assertEqual(t, table3GetColumnsHandler.Interactions, 1)
+					// 2, not 1: Update patches twice for the reason described above.
+					assertEqual(t, schemaPatchHandler.Interactions, 2)
 					return nil
 				},
 				resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "id", "connector_id"),

--- a/fivetran/tests/mock/resource_connector_schema_config_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_config_test.go
@@ -4963,7 +4963,8 @@ func TestResourceSchemaConfigTransientSchemaDuringRefreshWithAllowAllMock(t *tes
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 2)
+				// 4, not 2: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, getHandler.Interactions, 4)
 				assertEqual(t, patchHandler.Interactions, 0)
 				assertEqual(t, reloadHandler.Interactions, 0)
 				return nil
@@ -5011,7 +5012,8 @@ func TestResourceSchemaConfigTransientSchemaDuringRefreshWithAllowAllMock(t *tes
 		RefreshState: true,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 1)
+				// 2, not 1: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, getHandler.Interactions, 2)
 				assertEqual(t, patchHandler.Interactions, 0)
 				assertEqual(t, reloadHandler.Interactions, 0)
 				return nil
@@ -5041,7 +5043,8 @@ func TestResourceSchemaConfigTransientSchemaDuringRefreshWithAllowAllMock(t *tes
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 1)
+				// 2, not 1: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, getHandler.Interactions, 2)
 				assertEqual(t, patchHandler.Interactions, 0)
 				assertEqual(t, reloadHandler.Interactions, 0)
 				return nil
@@ -5093,7 +5096,8 @@ func TestResourceSchemaConfigTransientSchemaDuringRefreshWithAllowAllMock(t *tes
 			}`,
 		Check: resource.ComposeAggregateTestCheckFunc(
 			func(s *terraform.State) error {
-				assertEqual(t, getHandler.Interactions, 1)
+				// 2, not 1: ValidateConfig now calls GET .../schemas at plan time too.
+				assertEqual(t, getHandler.Interactions, 2)
 				assertEqual(t, patchHandler.Interactions, 0)
 				assertEqual(t, reloadHandler.Interactions, 0)
 				return nil

--- a/fivetran/tests/mock/resource_connector_schema_config_validate_config_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_config_validate_config_test.go
@@ -1,0 +1,42 @@
+package mock
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// Confirms the "only one of schemas/schema/schemas_json" check now fails at
+// terraform plan (via ValidateConfig), not just at apply. No mock HTTP handler
+// is registered for this test — if the check ran at apply time instead, this
+// test would fail with a connection error rather than the expected diagnostic.
+func TestResourceConnectorSchemaConfigValidateConfigConflictingFieldsMock(t *testing.T) {
+	step1 := resource.TestStep{
+		Config: `
+			resource "fivetran_connector_schema_config" "test_schema" {
+				provider     = fivetran-provider
+				connector_id = "connector_id"
+				schemas_json = jsonencode({
+					"schema_1" = {
+						enabled = true
+					}
+				})
+				schemas = {
+					"schema_1" = {
+						enabled = true
+					}
+				}
+			}`,
+		PlanOnly:    true,
+		ExpectError: regexp.MustCompile("You can use solely one field to define schema settings."),
+	}
+
+	resource.Test(
+		t,
+		resource.TestCase{
+			ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+			Steps:                    []resource.TestStep{step1},
+		},
+	)
+}


### PR DESCRIPTION
- Implement ValidateConfig on connectorSchema, moving the existing "only one of schemas/schema/schemas_json" check (IsValid()) to plan time instead of apply time
- Mark the now-redundant apply-time checks in Create/Update with TODO comments for future removal, without deleting them yet
- Add CHANGELOG entry under Unreleased