### PR TITLE
fivetran_connector_schema_config resource - fix schema tables object was empty, but now null failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.43...HEAD)
 
-### Fixed
-- `fivetran_connector_schema_config`: preserve explicitly configured empty `tables = {}` map in state instead of degrading it to null, fixing "Provider produced inconsistent result after apply: .schemas[...].tables: was cty.MapValEmpty(...), but now null" when all upstream tables match the `schema_change_handling` policy default.
 
 ## [v1.9.43](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.42...v1.9.43)
 
 ### Fixed
+- `fivetran_connector_schema_config`: preserve explicitly configured empty `tables = {}` map in state instead of degrading it to null, fixing "Provider produced inconsistent result after apply: .schemas[...].tables: was cty.MapValEmpty(...), but now null" when all upstream tables match the `schema_change_handling` policy default.
 - `fivetran_connection`: map `destination_schema.table_group_name` into `config.table_group_name` during connection creation, fixing SFTP creation when table group name is configured through `destination_schema`.
 - `fivetran_connector_schema_config`: a fix for a case when a disabled transient schema appeared in upstream, and TF-refresh performed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.43...HEAD)
 
+### Fixed
+- `fivetran_connector_schema_config`: preserve explicitly configured empty `tables = {}` map in state instead of degrading it to null, fixing "Provider produced inconsistent result after apply: .schemas[...].tables: was cty.MapValEmpty(...), but now null" when all upstream tables match the `schema_change_handling` policy default.
+
 ## [v1.9.43](https://github.com/fivetran/terraform-provider-fivetran/compare/v1.9.42...v1.9.43)
 
 ### Fixed

--- a/fivetran/framework/core/model/connector_schema_config.go
+++ b/fivetran/framework/core/model/connector_schema_config.go
@@ -298,6 +298,8 @@ func (d *ConnectorSchemaResourceModel) getSchemasMap(schemas []interface{}, isIm
 		}
 		if len(tables) > 0 {
 			schemaElements["tables"], _ = types.MapValue(types.ObjectType{AttrTypes: tablesAttrTypes}, tables)
+		} else if tablesAreNull, ok := localSchema["tables_are_null"].(bool); ok && !tablesAreNull {
+			schemaElements["tables"], _ = types.MapValue(types.ObjectType{AttrTypes: tablesAttrTypes}, tables)
 		} else {
 			schemaElements["tables"] = types.MapNull(types.ObjectType{AttrTypes: tablesAttrTypes})
 		}
@@ -588,6 +590,7 @@ func (d *ConnectorSchemaResourceModel) getSchemas() []interface{} {
 			schemas = append(schemas, schema)
 
 			if tablesMap, ok := schemaElement.Attributes()["tables"].(basetypes.MapValue); ok {
+				schema["tables_are_null"] = tablesMap.IsNull()
 				tables := []interface{}{}
 				for tName, te := range tablesMap.Elements() {
 					if tableElement, ok := te.(basetypes.ObjectValue); ok {

--- a/fivetran/tests/mock/resource_connector_schema_empty_tables_test.go
+++ b/fivetran/tests/mock/resource_connector_schema_empty_tables_test.go
@@ -1,0 +1,108 @@
+package mock
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const schemaConfigEmptyTablesMapJson = `
+{
+	"enable_new_by_default": true,
+	"schema_change_handling": "ALLOW_ALL",
+	"schemas": {
+		"schema_1": {
+			"name_in_destination": "schema_1",
+			"enabled": true,
+			"tables": {
+				"table_1": {
+					"name_in_destination": "table_1",
+					"enabled": true,
+					"enabled_patch_settings": {
+						"allowed": true
+					},
+					"columns": {
+						"column_1": {
+							"name_in_destination": "column_1",
+							"enabled": true,
+							"hashed": false,
+							"enabled_patch_settings": {
+								"allowed": true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+`
+
+// Reproduces "Provider produced inconsistent result after apply": with
+// schema_change_handling = "ALLOW_ALL" every enabled upstream table matches the
+// policy default and is filtered out of state, so an explicitly configured empty
+// `tables = {}` map must be kept as an empty map, not degraded to null.
+func TestResourceSchemaConfigEmptyTablesMapMock(t *testing.T) {
+	var schemaData map[string]interface{}
+
+	setupMockClient := func(t *testing.T) {
+		mockClient.Reset()
+		schemaData = nil
+
+		mockClient.When(http.MethodGet, "/v1/connections/connector_id/schemas").ThenCall(
+			func(req *http.Request) (*http.Response, error) {
+				if nil == schemaData {
+					schemaData = createMapFromJsonString(t, schemaConfigEmptyTablesMapJson)
+				}
+				return fivetranSuccessResponse(t, req, http.StatusOK, "Success", schemaData), nil
+			},
+		)
+
+		mockClient.When(http.MethodPatch, "/v1/connections/connector_id/schemas").ThenCall(
+			func(req *http.Request) (*http.Response, error) {
+				return fivetranSuccessResponse(t, req, http.StatusOK, "Success", schemaData), nil
+			},
+		)
+	}
+
+	step1 := resource.TestStep{
+		Config: `
+			resource "fivetran_connector_schema_config" "test_schema" {
+				provider = fivetran-provider
+				connector_id = "connector_id"
+				schema_change_handling = "ALLOW_ALL"
+				schemas = {
+					"schema_1" = {
+						enabled = true
+						tables = {}
+					}
+				}
+			}`,
+
+		Check: resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schema_change_handling", "ALLOW_ALL"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.enabled", "true"),
+			resource.TestCheckResourceAttr("fivetran_connector_schema_config.test_schema", "schemas.schema_1.tables.%", "0"),
+		),
+	}
+
+	resource.Test(
+		t,
+		resource.TestCase{
+			PreCheck: func() {
+				setupMockClient(t)
+			},
+			ProtoV6ProviderFactories: ProtoV6ProviderFactories,
+			CheckDestroy: func(s *terraform.State) error {
+				// there is no possibility to destroy schema config - it always exists within the connector
+				return nil
+			},
+
+			Steps: []resource.TestStep{
+				step1,
+			},
+		},
+	)
+}


### PR DESCRIPTION
`fivetran_connector_schema_config` resource - fix schema tables object was empty, but now null failure

With schema_change_handling = ALLOW_ALL, every enabled upstream table matches the policy default and is filtered out of state. An explicitly configured empty tables = {} map was then degraded to null, causing "Provider produced inconsistent result after apply".

Mirror the columns_are_null handling from #562 at the schema level: track whether the local tables map was explicitly non-null and preserve an empty map in state in that case.